### PR TITLE
Refine homepage language and visual hierarchy

### DIFF
--- a/src/app/data.json
+++ b/src/app/data.json
@@ -4,14 +4,14 @@
   "subdescription": "Jazz Vocalist and Guitarist",
   "email": "info@garydacanay.com",
   "hero": {
-    "eyebrow": "Jazz vocalist + guitarist",
+    "eyebrow": "Jazz vocalist & guitarist",
     "headline": "The Great American Songbook, Live.",
     "supportingCopy": "Timeless jazz for concerts, weddings, dinners, and private events.",
-    "stamp": "Available for your event"
+    "stamp": "Northeast\nOhio"
   },
   "navigation": [
-    { "label": "Listen", "href": "#listen" },
-    { "label": "For Hire", "href": "#for-hire" }
+    { "label": "Videos", "href": "#videos" },
+    { "label": "Events", "href": "#events" }
   ],
   "booking": {
     "subject": "Booking inquiry for Gary Dacanay",
@@ -38,7 +38,7 @@
   "videos": [
     ["Stella by Starlight", "SRjt5HgpgRM"],
     ["You Stepped Out Of A Dream", "ee68onP0OHg"],
-    ["Medley: The Way You Look Tonight", "aBUiJQaLWgs"]
+    ["The Way You Look Tonight — Medley", "aBUiJQaLWgs"]
   ],
   "social": {
     "youtube": "https://www.youtube.com/user/GaryDacanay",

--- a/src/app/data.json
+++ b/src/app/data.json
@@ -6,8 +6,7 @@
   "hero": {
     "eyebrow": "Jazz vocalist & guitarist",
     "headline": "The Great American Songbook, Live.",
-    "supportingCopy": "Timeless jazz for concerts, weddings, dinners, and private events.",
-    "stamp": "Northeast\nOhio"
+    "supportingCopy": "Timeless jazz for concerts, weddings, dinners, and private events."
   },
   "navigation": [
     { "label": "Videos", "href": "#videos" },

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -108,17 +108,14 @@
 .hero {
   position: relative;
   min-height: 100svh;
-  padding: 5.7rem clamp(1rem, 4vw, 4rem) 0;
+  padding: 5.7rem 0 0;
 }
 
 .heroGrid {
   display: grid;
-  width: min(100%, var(--container));
+  width: 100%;
   min-height: calc(100svh - 5.7rem);
   grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
-  margin: 0 auto;
-  border: 1px solid var(--color-rule);
-  border-bottom: 0;
 }
 
 .heroCopy {
@@ -127,19 +124,27 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: clamp(2.5rem, 6vw, 6.5rem) clamp(2rem, 5vw, 5.5rem);
+  padding: clamp(2.5rem, 6vw, 6.5rem) clamp(1rem, 4vw, 4rem);
 }
 
 .eyebrow,
 .sectionKicker,
-.darkKicker,
 .footerKicker {
   margin: 0;
   font-family: var(--font-display), sans-serif;
-  font-size: 0.82rem;
-  letter-spacing: 0.22em;
   line-height: 1.2;
   text-transform: uppercase;
+}
+
+.eyebrow,
+.sectionKicker {
+  font-size: clamp(0.9rem, 1vw, 1rem);
+  letter-spacing: 0.18em;
+}
+
+.footerKicker {
+  font-size: 0.82rem;
+  letter-spacing: 0.2em;
 }
 
 .eyebrow {
@@ -250,15 +255,17 @@
   width: clamp(7rem, 11vw, 10.5rem);
   aspect-ratio: 1;
   place-items: center;
-  border: 3px double var(--color-rust);
+  border: 3px double var(--color-gold);
   border-radius: 50%;
-  color: var(--color-rust);
+  color: var(--color-gold);
+  background: rgb(11 10 9 / 0.72);
   font-family: var(--font-display), sans-serif;
   font-size: clamp(0.95rem, 1.45vw, 1.35rem);
   letter-spacing: 0.1em;
-  line-height: 0.88;
+  line-height: 0.95;
   text-align: center;
   text-transform: uppercase;
+  white-space: pre-line;
   transform: rotate(-8deg);
 }
 
@@ -332,6 +339,7 @@
 .videoCard button {
   display: block;
   width: 100%;
+  height: 100%;
   border: 0;
   padding: 0;
   color: inherit;
@@ -392,16 +400,15 @@
 
 .videoMeta {
   display: grid;
-  min-height: 9rem;
+  min-height: 7.25rem;
   grid-template-columns: auto 1fr;
-  gap: 0.3rem 1rem;
+  gap: 1rem;
   align-content: start;
   padding: 1.2rem;
   border-top: 1px solid var(--color-rule);
 }
 
 .videoMeta > span:first-child {
-  grid-row: 1 / 3;
   color: var(--color-rust);
   font-family: var(--font-display), sans-serif;
   font-size: 0.8rem;
@@ -414,13 +421,6 @@
   font-weight: 400;
   line-height: 0.95;
   letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.videoMeta > span:last-child {
-  color: var(--color-paper-muted);
-  font-size: 0.68rem;
-  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
@@ -504,8 +504,17 @@
   gap: clamp(3rem, 7vw, 8rem);
 }
 
-.darkKicker {
-  color: rgb(11 10 9 / 0.66);
+.availabilityLine {
+  width: fit-content;
+  margin: 0;
+  border-left: 0.22rem solid var(--color-ink);
+  padding-left: 0.8rem;
+  color: var(--color-ink);
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(1rem, 1.35vw, 1.2rem);
+  letter-spacing: 0.14em;
+  line-height: 1.15;
+  text-transform: uppercase;
 }
 
 .forHireIntro h2 {
@@ -518,7 +527,7 @@
   text-transform: uppercase;
 }
 
-.forHireIntro > p:not(.darkKicker) {
+.forHireIntro > p:not(.availabilityLine) {
   max-width: 35rem;
   margin: 1.5rem 0 0;
   font-family: var(--font-serif), Georgia, serif;
@@ -564,9 +573,9 @@
 
 .service p {
   margin: 0.8rem 0 0;
-  color: rgb(11 10 9 / 0.74);
-  font-size: 0.9rem;
-  line-height: 1.6;
+  color: rgb(11 10 9 / 0.8);
+  font-size: 1rem;
+  line-height: 1.55;
 }
 
 .socialLinks img {
@@ -592,9 +601,12 @@
   color: var(--color-rust);
 }
 
-.footerBooking h2,
-.newsletter h2 {
+.footerBooking h2 {
   font-size: clamp(3.6rem, 6vw, 6.6rem);
+}
+
+.newsletter h2 {
+  font-size: clamp(2.9rem, 4.2vw, 4.7rem);
 }
 
 .footerBooking > p:not(.footerKicker),
@@ -759,6 +771,10 @@
 }
 
 @media (max-width: 899px) {
+  .navScrolled {
+    backdrop-filter: none;
+  }
+
   .desktopNavigation {
     display: none;
   }
@@ -821,7 +837,6 @@
   .heroGrid {
     min-height: calc(100svh - 5.7rem);
     grid-template-columns: 1fr;
-    border-inline: 0;
   }
 
   .heroCopy {
@@ -867,7 +882,7 @@
   }
 
   .videoMeta {
-    min-height: 7rem;
+    min-height: 6rem;
   }
 
   .forHireShell,
@@ -942,9 +957,12 @@
 
   .sectionHeader h2,
   .forHireIntro h2,
-  .footerBooking h2,
-  .newsletter h2 {
+  .footerBooking h2 {
     font-size: clamp(3.4rem, 17vw, 5rem);
+  }
+
+  .newsletter h2 {
+    font-size: clamp(2.9rem, 14vw, 4.2rem);
   }
 
   .serviceGrid {

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -129,6 +129,7 @@
 
 .eyebrow,
 .sectionKicker,
+.eventsKicker,
 .footerKicker {
   margin: 0;
   font-family: var(--font-display), sans-serif;
@@ -137,7 +138,8 @@
 }
 
 .eyebrow,
-.sectionKicker {
+.sectionKicker,
+.eventsKicker {
   font-size: clamp(0.9rem, 1vw, 1rem);
   letter-spacing: 0.18em;
 }
@@ -149,6 +151,10 @@
 
 .eyebrow {
   color: var(--color-rust);
+}
+
+.eventsKicker {
+  color: rgb(11 10 9 / 0.72);
 }
 
 .heroTitle {
@@ -244,29 +250,6 @@
 .heroImage {
   object-fit: cover;
   object-position: 50% 18%;
-}
-
-.availabilityStamp {
-  position: absolute;
-  top: 8%;
-  right: 5%;
-  z-index: 3;
-  display: grid;
-  width: clamp(7rem, 11vw, 10.5rem);
-  aspect-ratio: 1;
-  place-items: center;
-  border: 3px double var(--color-gold);
-  border-radius: 50%;
-  color: var(--color-gold);
-  background: rgb(11 10 9 / 0.72);
-  font-family: var(--font-display), sans-serif;
-  font-size: clamp(0.95rem, 1.45vw, 1.35rem);
-  letter-spacing: 0.1em;
-  line-height: 0.95;
-  text-align: center;
-  text-transform: uppercase;
-  white-space: pre-line;
-  transform: rotate(-8deg);
 }
 
 .performances {
@@ -504,19 +487,6 @@
   gap: clamp(3rem, 7vw, 8rem);
 }
 
-.availabilityLine {
-  width: fit-content;
-  margin: 0;
-  border-left: 0.22rem solid var(--color-ink);
-  padding-left: 0.8rem;
-  color: var(--color-ink);
-  font-family: var(--font-display), sans-serif;
-  font-size: clamp(1rem, 1.35vw, 1.2rem);
-  letter-spacing: 0.14em;
-  line-height: 1.15;
-  text-transform: uppercase;
-}
-
 .forHireIntro h2 {
   max-width: 8ch;
   margin: 0.45rem 0 0;
@@ -527,7 +497,7 @@
   text-transform: uppercase;
 }
 
-.forHireIntro > p:not(.availabilityLine) {
+.forHireIntro > p:not(.eventsKicker) {
   max-width: 35rem;
   margin: 1.5rem 0 0;
   font-family: var(--font-serif), Georgia, serif;
@@ -868,10 +838,6 @@
     object-position: 50% 13%;
   }
 
-  .availabilityStamp {
-    top: 14%;
-  }
-
   .sectionHeader {
     grid-template-columns: 1fr;
     gap: 1rem;
@@ -943,11 +909,6 @@
   .heroArtwork {
     min-height: 34rem;
     margin-top: -4rem;
-  }
-
-  .availabilityStamp {
-    width: 6.6rem;
-    font-size: 0.85rem;
   }
 
   .performances,

--- a/src/app/home/HomePage.tsx
+++ b/src/app/home/HomePage.tsx
@@ -53,9 +53,6 @@ export function HomePage() {
                 sizes="(max-width: 899px) 100vw, 56vw"
                 className={styles.heroImage}
               />
-              <span className={styles.availabilityStamp}>
-                {data.hero.stamp}
-              </span>
             </div>
           </div>
         </section>
@@ -65,12 +62,11 @@ export function HomePage() {
         <section id="events" className={styles.forHire} aria-labelledby="events-title">
           <div className={styles.forHireShell}>
             <div className={styles.forHireIntro}>
-              <p className={styles.availabilityLine}>Available throughout Northeast Ohio</p>
+              <p className={styles.eventsKicker}>Shaped Around The Occasion</p>
               <h2 id="events-title">Music for Any Room.</h2>
               <p>
-                A polished performance shaped around the occasion—welcoming when
-                guests arrive, atmospheric through dinner, and memorable when the music
-                takes center stage.
+                A polished performance—welcoming as guests arrive, atmospheric through
+                dinner, and memorable when the music takes center stage.
               </p>
               <a className={styles.darkButton} href={bookingHref}>
                 Check availability

--- a/src/app/home/HomePage.tsx
+++ b/src/app/home/HomePage.tsx
@@ -36,10 +36,10 @@ export function HomePage() {
               <p className={styles.heroSupporting}>{data.hero.supportingCopy}</p>
               <div className={styles.heroActions}>
                 <a className={styles.primaryButton} href={bookingHref}>
-                  Book Gary
+                  Check availability
                 </a>
-                <a className={styles.secondaryButton} href="#listen">
-                  Watch &amp; listen
+                <a className={styles.secondaryButton} href="#videos">
+                  Watch videos
                 </a>
               </div>
             </div>
@@ -53,12 +53,8 @@ export function HomePage() {
                 sizes="(max-width: 899px) 100vw, 56vw"
                 className={styles.heroImage}
               />
-              <span className={styles.availabilityStamp} aria-hidden="true">
-                Available
-                <br />
-                for your
-                <br />
-                event
+              <span className={styles.availabilityStamp}>
+                {data.hero.stamp}
               </span>
             </div>
           </div>
@@ -66,18 +62,18 @@ export function HomePage() {
 
         <Performances videos={videos} />
 
-        <section id="for-hire" className={styles.forHire} aria-labelledby="hire-title">
+        <section id="events" className={styles.forHire} aria-labelledby="events-title">
           <div className={styles.forHireShell}>
             <div className={styles.forHireIntro}>
-              <p className={styles.darkKicker}>Available throughout Northeast Ohio</p>
-              <h2 id="hire-title">Music for Any Room.</h2>
+              <p className={styles.availabilityLine}>Available throughout Northeast Ohio</p>
+              <h2 id="events-title">Music for Any Room.</h2>
               <p>
-                A polished solo performance shaped around the occasion—welcoming when
+                A polished performance shaped around the occasion—welcoming when
                 guests arrive, atmospheric through dinner, and memorable when the music
                 takes center stage.
               </p>
               <a className={styles.darkButton} href={bookingHref}>
-                Start a booking inquiry
+                Check availability
               </a>
             </div>
 
@@ -101,11 +97,11 @@ export function HomePage() {
             <p className={styles.footerKicker}>Bring the songbook to your event</p>
             <h2>Let&apos;s make the room swing.</h2>
             <p>
-              Tell Gary about the occasion, date, location, and guest count. The booking
-              link opens a ready-to-complete email inquiry.
+              Share the date, location, occasion, and guest count. Gary will follow up
+              with availability.
             </p>
             <a className={styles.primaryButton} href={bookingHref}>
-              Book Gary
+              Check availability
             </a>
             <a className={styles.emailLink} href={`mailto:${data.email}`}>
               {data.email}

--- a/src/app/home/NavBar.tsx
+++ b/src/app/home/NavBar.tsx
@@ -58,7 +58,7 @@ export function NavBar({
           </a>
         ))}
         <a className={styles.navBooking} href={bookingHref}>
-          Book
+          Check availability
         </a>
       </nav>
 
@@ -85,7 +85,7 @@ export function NavBar({
           </a>
         ))}
         <a className={styles.mobileBooking} href={bookingHref} onClick={() => setOpen(false)}>
-          Book Gary
+          Check availability
         </a>
       </nav>
     </header>

--- a/src/app/home/NewsletterForm.tsx
+++ b/src/app/home/NewsletterForm.tsx
@@ -41,8 +41,8 @@ export function NewsletterForm() {
   return (
     <div className={styles.newsletter}>
       <p className={styles.footerKicker}>Notes from the bandstand</p>
-      <h2>Get Updates.</h2>
-      <p>Occasional news about performances, recordings, and new music.</p>
+      <h2>Stay in the Loop.</h2>
+      <p>Occasional notes about upcoming performances, recordings, and new music.</p>
       <form onSubmit={handleSubmit} className={styles.newsletterForm}>
         <label htmlFor="newsletter-email">Email address</label>
         <div>

--- a/src/app/home/Performances.tsx
+++ b/src/app/home/Performances.tsx
@@ -23,15 +23,14 @@ export function Performances({ videos }: { videos: Video[] }) {
   const closeModal = () => dialogRef.current?.close();
 
   return (
-    <section id="listen" className={styles.performances} aria-labelledby="performances-title">
+    <section id="videos" className={styles.performances} aria-labelledby="performances-title">
       <div className={styles.sectionHeader}>
         <div>
           <p className={styles.sectionKicker}>Selected performances</p>
-          <h2 id="performances-title">Press Play.</h2>
+          <h2 id="performances-title">Videos.</h2>
         </div>
         <p>
-          Three standards, performed with the intimacy and warmth Gary brings to a live
-          room.
+          Standards performed with the intimacy and warmth Gary brings to a live room.
         </p>
       </div>
 
@@ -60,7 +59,6 @@ export function Performances({ videos }: { videos: Video[] }) {
               <span className={styles.videoMeta}>
                 <span>{String(index + 1).padStart(2, "0")}</span>
                 <strong>{video.title}</strong>
-                <span>Watch performance</span>
               </span>
             </button>
           </article>


### PR DESCRIPTION
Closes #26

## Changes
- make the hero poster full width while preserving aligned content gutters
- remove the hero location badge so the photograph remains uninterrupted
- rename the primary sections and anchors to Videos and Events
- simplify video-card captions and normalize performance copy
- use “Shaped Around The Occasion” as the Events eyebrow and tighten its supporting paragraph
- standardize booking calls to action and rewrite footer copy around visitor intent
- improve eyebrow, supporting-copy, video-card, and footer hierarchy
- fix the full-screen mobile menu when opened from a scrolled position

## Validation
- `pnpm lint` — passed
- `pnpm build` — passed
- `git diff --check` — passed
- Prettier check could not start because the existing `.prettierrc` references `prettier-plugin-tailwindcss`, which is not installed

## Docs updated
- Not applicable; no source-of-truth documentation changed

## Manual validation
- inspected the hero, Videos, Events, and footer at desktop size
- inspected the hero, Videos, Events, footer, and navigation at mobile size
- verified the mobile menu from a scrolled page position
- verified no browser console errors

## Follow-ups
- add authentic testimonial or venue social proof when suitable material is available
- confirm Gary’s travel preferences before adding any visible location or availability language
- repair the existing Prettier plugin configuration separately