### PR TITLE
Reduce marketing-heavy homepage copy

### DIFF
--- a/src/app/data.json
+++ b/src/app/data.json
@@ -1,11 +1,9 @@
 {
   "name": "Gary Dacanay",
   "description": "Live jazz standards and Great American Songbook favorites for weddings, dinners, concerts, corporate receptions, and private events in Northeast Ohio.",
-  "subdescription": "Jazz Vocalist and Guitarist",
   "email": "info@garydacanay.com",
   "hero": {
-    "eyebrow": "Jazz vocalist & guitarist",
-    "headline": "The Great American Songbook, Live.",
+    "headline": "The Great American Songbook, Live",
     "supportingCopy": "Timeless jazz for concerts, weddings, dinners, and private events."
   },
   "navigation": [

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -127,39 +127,9 @@
   padding: clamp(2.5rem, 6vw, 6.5rem) clamp(1rem, 4vw, 4rem);
 }
 
-.eyebrow,
-.sectionKicker,
-.eventsKicker,
-.footerKicker {
-  margin: 0;
-  font-family: var(--font-display), sans-serif;
-  line-height: 1.2;
-  text-transform: uppercase;
-}
-
-.eyebrow,
-.sectionKicker,
-.eventsKicker {
-  font-size: clamp(0.9rem, 1vw, 1rem);
-  letter-spacing: 0.18em;
-}
-
-.footerKicker {
-  font-size: 0.82rem;
-  letter-spacing: 0.2em;
-}
-
-.eyebrow {
-  color: var(--color-rust);
-}
-
-.eventsKicker {
-  color: rgb(11 10 9 / 0.72);
-}
-
 .heroTitle {
   max-width: 7ch;
-  margin: 0.5rem 0 0;
+  margin: 0;
   font-family: var(--font-display), sans-serif;
   font-size: clamp(5rem, 7.4vw, 9rem);
   font-weight: 400;
@@ -273,21 +243,17 @@
 
 .sectionHeader {
   display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(18rem, 0.55fr);
+  grid-template-columns: minmax(0, 1fr);
   align-items: end;
   gap: 3rem;
   padding-bottom: 2rem;
   border-bottom: 1px solid var(--color-rule);
 }
 
-.sectionKicker {
-  color: var(--color-teal);
-}
-
 .sectionHeader h2,
 .footerBooking h2,
 .newsletter h2 {
-  margin: 0.35rem 0 0;
+  margin: 0;
   font-family: var(--font-display), sans-serif;
   font-weight: 400;
   line-height: 0.9;
@@ -296,15 +262,6 @@
 
 .sectionHeader h2 {
   font-size: clamp(3.5rem, 7vw, 7.5rem);
-}
-
-.sectionHeader > p {
-  margin: 0;
-  color: var(--color-paper-muted);
-  font-family: var(--font-serif), Georgia, serif;
-  font-size: 1.35rem;
-  font-style: italic;
-  line-height: 1.4;
 }
 
 .videoGrid {
@@ -489,7 +446,7 @@
 
 .forHireIntro h2 {
   max-width: 8ch;
-  margin: 0.45rem 0 0;
+  margin: 0;
   font-family: var(--font-display), sans-serif;
   font-size: clamp(4rem, 7vw, 7.5rem);
   font-weight: 400;
@@ -497,7 +454,7 @@
   text-transform: uppercase;
 }
 
-.forHireIntro > p:not(.eventsKicker) {
+.forHireIntro > p {
   max-width: 35rem;
   margin: 1.5rem 0 0;
   font-family: var(--font-serif), Georgia, serif;
@@ -567,10 +524,6 @@
   padding: clamp(5rem, 9vw, 9rem) clamp(1rem, 4vw, 4rem);
 }
 
-.footerKicker {
-  color: var(--color-rust);
-}
-
 .footerBooking h2 {
   font-size: clamp(3.6rem, 6vw, 6.6rem);
 }
@@ -579,8 +532,8 @@
   font-size: clamp(2.9rem, 4.2vw, 4.7rem);
 }
 
-.footerBooking > p:not(.footerKicker),
-.newsletter > p:not(.footerKicker),
+.footerBooking > p,
+.newsletter > p,
 .socialBlock > p {
   max-width: 34rem;
   margin: 1.25rem 0 0;

--- a/src/app/home/HomePage.tsx
+++ b/src/app/home/HomePage.tsx
@@ -23,7 +23,6 @@ export function HomePage() {
         <section id="top" className={styles.hero} aria-labelledby="hero-title">
           <div className={styles.heroGrid}>
             <div className={styles.heroCopy}>
-              <p className={styles.eyebrow}>{data.hero.eyebrow}</p>
               <h1 id="hero-title" className={styles.heroTitle}>
                 The Great
                 <br />
@@ -31,7 +30,7 @@ export function HomePage() {
                 <br />
                 Songbook,
                 <br />
-                <span>Live.</span>
+                <span>Live</span>
               </h1>
               <p className={styles.heroSupporting}>{data.hero.supportingCopy}</p>
               <div className={styles.heroActions}>
@@ -62,8 +61,7 @@ export function HomePage() {
         <section id="events" className={styles.forHire} aria-labelledby="events-title">
           <div className={styles.forHireShell}>
             <div className={styles.forHireIntro}>
-              <p className={styles.eventsKicker}>Shaped Around The Occasion</p>
-              <h2 id="events-title">Music for Any Room.</h2>
+              <h2 id="events-title">Music for Any Room</h2>
               <p>
                 A polished performance—welcoming as guests arrive, atmospheric through
                 dinner, and memorable when the music takes center stage.
@@ -90,8 +88,7 @@ export function HomePage() {
       <footer id="contact" className={styles.footer}>
         <div className={styles.footerMain}>
           <div className={styles.footerBooking}>
-            <p className={styles.footerKicker}>Bring the songbook to your event</p>
-            <h2>Let&apos;s make the room swing.</h2>
+            <h2>Bring the songbook to your event</h2>
             <p>
               Share the date, location, occasion, and guest count. Gary will follow up
               with availability.

--- a/src/app/home/NewsletterForm.tsx
+++ b/src/app/home/NewsletterForm.tsx
@@ -40,9 +40,8 @@ export function NewsletterForm() {
 
   return (
     <div className={styles.newsletter}>
-      <p className={styles.footerKicker}>Notes from the bandstand</p>
-      <h2>Stay in the Loop.</h2>
-      <p>Occasional notes about upcoming performances, recordings, and new music.</p>
+      <h2>Stay in the Loop</h2>
+      <p>Occasional messages about upcoming performances, recordings, and new music.</p>
       <form onSubmit={handleSubmit} className={styles.newsletterForm}>
         <label htmlFor="newsletter-email">Email address</label>
         <div>

--- a/src/app/home/Performances.tsx
+++ b/src/app/home/Performances.tsx
@@ -26,12 +26,8 @@ export function Performances({ videos }: { videos: Video[] }) {
     <section id="videos" className={styles.performances} aria-labelledby="performances-title">
       <div className={styles.sectionHeader}>
         <div>
-          <p className={styles.sectionKicker}>Selected performances</p>
-          <h2 id="performances-title">Videos.</h2>
+          <h2 id="performances-title">Videos</h2>
         </div>
-        <p>
-          Standards performed with the intimacy and warmth Gary brings to a live room.
-        </p>
       </div>
 
       <div className={styles.videoGrid}>


### PR DESCRIPTION
## Changes
- Remove visible eyebrow labels and the performance blurb.
- Simplify display-heading punctuation by removing periods.
- Make “Bring the songbook to your event” the footer heading.
- Change newsletter copy from “notes” to “messages.”
- Preserve SEO and structured-data role language.

## Validation
- `pnpm lint`
- `pnpm build`
- `git diff --check`

## Docs updated
- None needed; this is a visible-copy refinement.

## Manual validation
- Confirmed the removed phrases and obsolete kicker class references are absent from the rendered-copy sources.

## Follow-ups
- No production merge or deployment performed.