### PR TITLE
Build inline homepage video showcase

### DIFF
--- a/src/app/data.json
+++ b/src/app/data.json
@@ -33,9 +33,13 @@
     }
   ],
   "videos": [
+    ["Haven’t We Met", "EuolPrEogoc"],
+    ["In a Sentimental Mood", "6_HX6vTfS-4"],
+    ["Beyond the Sea", "rtxGXTqMXdw"],
+    ["My Funny Valentine", "HTHvkNXp8G4"],
     ["Stella by Starlight", "SRjt5HgpgRM"],
-    ["You Stepped Out Of A Dream", "ee68onP0OHg"],
-    ["The Way You Look Tonight — Medley", "aBUiJQaLWgs"]
+    ["You Stepped Out of a Dream", "ee68onP0OHg"],
+    ["The Way You Look Tonight", "aBUiJQaLWgs"]
   ],
   "social": {
     "youtube": "https://www.youtube.com/user/GaryDacanay",

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -233,7 +233,7 @@
 }
 
 .sectionHeader,
-.videoGrid,
+.videoExperience,
 .forHireShell,
 .footerMain,
 .footerBottom {
@@ -242,12 +242,7 @@
 }
 
 .sectionHeader {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  align-items: end;
-  gap: 3rem;
-  padding-bottom: 2rem;
-  border-bottom: 1px solid var(--color-rule);
+  padding-bottom: 0;
 }
 
 .sectionHeader h2,
@@ -261,169 +256,184 @@
 }
 
 .sectionHeader h2 {
-  font-size: clamp(3.5rem, 7vw, 7.5rem);
+  font-size: clamp(3.5rem, 5vw, 5.5rem);
 }
 
-.videoGrid {
+.videoExperience {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1.25rem;
-  margin-top: 2rem;
+  grid-template-columns: minmax(0, 1.75fr) minmax(20rem, 1fr);
+  gap: clamp(2rem, 4vw, 4rem);
+  align-items: start;
+  margin-top: 2.25rem;
 }
 
-.videoCard {
-  border: 1px solid var(--color-rule);
-  background: var(--color-ink-soft);
+.videoStage,
+.videoPlaylist {
+  min-width: 0;
 }
 
-.videoCard button {
-  display: block;
-  width: 100%;
-  height: 100%;
-  border: 0;
-  padding: 0;
-  color: inherit;
-  background: transparent;
-  text-align: left;
-}
-
-.videoMedia {
+.featuredMedia {
   position: relative;
-  display: block;
   aspect-ratio: 16 / 9;
   overflow: hidden;
+  border-radius: 0.75rem;
   background: #050504;
 }
 
-.videoMedia img {
+.featuredMedia iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.featuredPlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  border: 0;
+  padding: 0;
+  color: var(--color-ink);
+  background: transparent;
+}
+
+.featuredPlay:focus-visible {
+  outline-offset: -4px;
+}
+
+.featuredPlay::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: rgb(11 10 9 / 0.18);
+  transition: background-color 200ms ease;
+}
+
+.featuredPlay img {
   object-fit: cover;
-  filter: saturate(0.55) contrast(1.08) sepia(0.24);
+  filter: saturate(0.65) contrast(1.06) sepia(0.18);
   transition:
     filter 240ms ease,
     transform 360ms ease;
 }
 
-.videoOverlay {
+.featuredPlayIcon {
   position: absolute;
-  inset: 0;
+  inset: 50% auto auto 50%;
+  z-index: 1;
   display: grid;
   place-items: center;
-  color: var(--color-ink);
-  background: rgb(11 10 9 / 0.22);
-  transition: background-color 200ms ease;
-}
-
-.videoOverlay svg {
-  box-sizing: content-box;
-  border: 1px solid rgb(11 10 9 / 0.4);
+  width: 4.5rem;
+  height: 4.5rem;
+  border: 1px solid rgb(11 10 9 / 0.42);
   border-radius: 50%;
-  padding: 1rem;
+  color: var(--color-ink);
   background: var(--color-gold);
-  transition: transform 180ms ease;
+  transform: translate(-50%, -50%);
+  transition:
+    background-color 180ms ease,
+    transform 180ms ease;
 }
 
-.videoCard button:hover .videoMedia img,
-.videoCard button:focus-visible .videoMedia img {
-  filter: saturate(0.82) contrast(1.08) sepia(0.12);
+.featuredPlay:hover img,
+.featuredPlay:focus-visible img {
+  filter: saturate(0.82) contrast(1.06) sepia(0.08);
   transform: scale(1.035);
 }
 
-.videoCard button:hover .videoOverlay,
-.videoCard button:focus-visible .videoOverlay {
+.featuredPlay:hover::after,
+.featuredPlay:focus-visible::after {
   background: rgb(11 10 9 / 0.06);
 }
 
-.videoCard button:hover .videoOverlay svg,
-.videoCard button:focus-visible .videoOverlay svg {
-  transform: scale(1.08);
+.featuredPlay:hover .featuredPlayIcon,
+.featuredPlay:focus-visible .featuredPlayIcon {
+  background: var(--color-paper);
+  transform: translate(-50%, -50%) scale(1.06);
 }
 
-.videoMeta {
-  display: grid;
-  min-height: 7.25rem;
-  grid-template-columns: auto 1fr;
-  gap: 1rem;
-  align-content: start;
-  padding: 1.2rem;
-  border-top: 1px solid var(--color-rule);
-}
-
-.videoMeta > span:first-child {
-  color: var(--color-rust);
+.activeVideoTitle {
+  max-width: 16ch;
+  margin: 1.25rem 0 0;
   font-family: var(--font-display), sans-serif;
-  font-size: 0.8rem;
-  letter-spacing: 0.1em;
-}
-
-.videoMeta strong {
-  font-family: var(--font-display), sans-serif;
-  font-size: clamp(1.6rem, 2.5vw, 2.6rem);
+  font-size: clamp(2.8rem, 4.4vw, 5rem);
   font-weight: 400;
-  line-height: 0.95;
+  line-height: 0.9;
   letter-spacing: 0.02em;
   text-transform: uppercase;
 }
 
-.videoDialog {
-  width: min(92vw, 72rem);
-  max-width: none;
-  border: 1px solid var(--color-gold);
+.videoPlaylist {
+  display: grid;
+  gap: 0.4rem;
+  margin: -0.45rem 0 0;
   padding: 0;
-  color: var(--color-paper);
-  background: var(--color-ink);
-  box-shadow: 0 2rem 8rem rgb(0 0 0 / 0.72);
+  list-style: none;
 }
 
-.videoDialog::backdrop {
-  background: rgb(0 0 0 / 0.84);
-  backdrop-filter: blur(8px);
-}
-
-.dialogPanel {
+.videoPlaylist li {
   min-width: 0;
 }
 
-.dialogHeader {
-  display: flex;
-  min-height: 4rem;
+.playlistItem {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(7rem, 9.25rem) auto minmax(0, 1fr);
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.8rem 1rem 0.8rem 1.25rem;
-  border-bottom: 1px solid var(--color-rule);
+  gap: 0.8rem;
+  border: 0;
+  border-radius: 0.75rem;
+  padding: 0.45rem;
+  color: var(--color-paper);
+  background: transparent;
+  text-align: left;
+  transition: background-color 160ms ease;
 }
 
-.dialogHeader h3 {
-  margin: 0;
+.playlistItem:hover,
+.playlistItem:focus-visible,
+.playlistItemActive {
+  background: rgb(244 228 184 / 0.07);
+}
+
+.playlistThumbnail {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  background: #050504;
+}
+
+.playlistThumbnail img {
+  object-fit: cover;
+  filter: saturate(0.58) contrast(1.06) sepia(0.18);
+  transition: filter 180ms ease;
+}
+
+.playlistItem:hover .playlistThumbnail img,
+.playlistItem:focus-visible .playlistThumbnail img,
+.playlistItemActive .playlistThumbnail img {
+  filter: saturate(0.82) contrast(1.06) sepia(0.08);
+}
+
+.playlistNumber,
+.playlistItem strong {
   font-family: var(--font-display), sans-serif;
-  font-size: 1.4rem;
   font-weight: 400;
-  letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
-.dialogHeader button {
-  display: inline-flex;
-  width: 2.5rem;
-  height: 2.5rem;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--color-rule);
-  color: var(--color-paper);
-  background: transparent;
+.playlistNumber {
+  color: var(--color-rust);
+  font-size: 1.15rem;
+  letter-spacing: 0.06em;
 }
 
-.videoEmbed {
-  position: relative;
-  aspect-ratio: 16 / 9;
-}
-
-.videoEmbed iframe {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
+.playlistItem strong {
+  font-size: clamp(1.2rem, 1.55vw, 1.65rem);
+  line-height: 0.95;
+  letter-spacing: 0.025em;
 }
 
 .forHire {
@@ -679,12 +689,18 @@
     font-size: clamp(4.5rem, 7.5vw, 6.5rem);
   }
 
-  .videoGrid {
-    gap: 0.8rem;
+  .videoExperience {
+    grid-template-columns: minmax(0, 1.55fr) minmax(19rem, 1fr);
+    gap: 2rem;
   }
 
-  .videoMeta {
-    padding: 1rem;
+  .playlistItem {
+    grid-template-columns: 6.5rem auto minmax(0, 1fr);
+    gap: 0.65rem;
+  }
+
+  .playlistItem strong {
+    font-size: 1.15rem;
   }
 
   .forHireShell,
@@ -791,17 +807,46 @@
     object-position: 50% 13%;
   }
 
-  .sectionHeader {
+  .videoExperience {
     grid-template-columns: 1fr;
-    gap: 1rem;
+    gap: 2rem;
   }
 
-  .videoGrid {
-    grid-template-columns: 1fr;
+  .videoPlaylist {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(15rem, 42vw);
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0.25rem 0.25rem 1rem;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scroll-snap-type: inline mandatory;
+    scrollbar-width: thin;
   }
 
-  .videoMeta {
-    min-height: 6rem;
+  .videoPlaylist::-webkit-scrollbar {
+    height: 0.35rem;
+  }
+
+  .videoPlaylist::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .videoPlaylist::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: rgb(244 228 184 / 0.24);
+  }
+
+  .videoPlaylist li {
+    scroll-snap-align: start;
+  }
+
+  .playlistItem {
+    grid-template-columns: minmax(6.5rem, 43%) auto minmax(0, 1fr);
+  }
+
+  .playlistItem strong {
+    font-size: clamp(1.15rem, 2.8vw, 1.5rem);
   }
 
   .forHireShell,
@@ -877,6 +922,32 @@
 
   .newsletter h2 {
     font-size: clamp(2.9rem, 14vw, 4.2rem);
+  }
+
+  .videoExperience {
+    margin-top: 1.6rem;
+  }
+
+  .featuredMedia {
+    border-radius: 0.625rem;
+  }
+
+  .featuredPlayIcon {
+    width: 4rem;
+    height: 4rem;
+  }
+
+  .activeVideoTitle {
+    margin-top: 1rem;
+    font-size: clamp(2.8rem, 13vw, 4rem);
+  }
+
+  .videoPlaylist {
+    grid-auto-columns: 76vw;
+  }
+
+  .playlistItem {
+    grid-template-columns: 40% auto minmax(0, 1fr);
   }
 
   .serviceGrid {

--- a/src/app/home/Performances.tsx
+++ b/src/app/home/Performances.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Image from "next/image";
-import { Play, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Play } from "lucide-react";
+import { useState } from "react";
 import styles from "./HomePage.module.css";
 
 type Video = {
@@ -11,87 +11,87 @@ type Video = {
 };
 
 export function Performances({ videos }: { videos: Video[] }) {
-  const [activeVideo, setActiveVideo] = useState<Video | null>(null);
-  const dialogRef = useRef<HTMLDialogElement>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [activeVideo, setActiveVideo] = useState<Video | null>(videos[0] ?? null);
+  const [isPlaying, setIsPlaying] = useState(false);
 
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (activeVideo && dialog && !dialog.open) dialog.showModal();
-  }, [activeVideo]);
-
-  const closeModal = () => dialogRef.current?.close();
+  const playVideo = (video: Video) => {
+    setActiveVideo(video);
+    setIsPlaying(true);
+  };
 
   return (
     <section id="videos" className={styles.performances} aria-labelledby="performances-title">
       <div className={styles.sectionHeader}>
-        <div>
-          <h2 id="performances-title">Videos</h2>
-        </div>
+        <h2 id="performances-title">Videos</h2>
       </div>
 
-      <div className={styles.videoGrid}>
-        {videos.map((video, index) => (
-          <article className={styles.videoCard} key={video.id}>
-            <button
-              type="button"
-              aria-label={`Play ${video.title}`}
-              onClick={(event) => {
-                triggerRef.current = event.currentTarget;
-                setActiveVideo(video);
-              }}
-            >
-              <span className={styles.videoMedia}>
-                <Image
-                  src={`https://img.youtube.com/vi/${video.id}/maxresdefault.jpg`}
-                  alt=""
-                  fill
-                  sizes="(max-width: 760px) 100vw, 33vw"
+      {activeVideo ? (
+        <div className={styles.videoExperience}>
+          <div className={styles.videoStage}>
+            <div className={styles.featuredMedia}>
+              {isPlaying ? (
+                <iframe
+                  key={activeVideo.id}
+                  src={`https://www.youtube-nocookie.com/embed/${activeVideo.id}?autoplay=1&rel=0`}
+                  title={activeVideo.title}
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  allowFullScreen
                 />
-                <span className={styles.videoOverlay}>
-                  <Play size={24} fill="currentColor" />
-                </span>
-              </span>
-              <span className={styles.videoMeta}>
-                <span>{String(index + 1).padStart(2, "0")}</span>
-                <strong>{video.title}</strong>
-              </span>
-            </button>
-          </article>
-        ))}
-      </div>
-
-      <dialog
-        ref={dialogRef}
-        className={styles.videoDialog}
-        aria-label={activeVideo ? `Video: ${activeVideo.title}` : "Performance video"}
-        onClick={(event) => {
-          if (event.target === event.currentTarget) closeModal();
-        }}
-        onClose={() => {
-          setActiveVideo(null);
-          requestAnimationFrame(() => triggerRef.current?.focus());
-        }}
-      >
-        <div className={styles.dialogPanel}>
-          <div className={styles.dialogHeader}>
-            <h3>{activeVideo?.title}</h3>
-            <button type="button" onClick={closeModal} aria-label="Close video">
-              <X size={22} />
-            </button>
-          </div>
-          {activeVideo ? (
-            <div className={styles.videoEmbed}>
-              <iframe
-                src={`https://www.youtube-nocookie.com/embed/${activeVideo.id}?autoplay=1&rel=0`}
-                title={activeVideo.title}
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                allowFullScreen
-              />
+              ) : (
+                <button
+                  type="button"
+                  className={styles.featuredPlay}
+                  aria-label={`Play ${activeVideo.title}`}
+                  onClick={() => setIsPlaying(true)}
+                >
+                  <Image
+                    src={`https://img.youtube.com/vi/${activeVideo.id}/maxresdefault.jpg`}
+                    alt=""
+                    fill
+                    sizes="(max-width: 899px) 100vw, 64vw"
+                  />
+                  <span className={styles.featuredPlayIcon} aria-hidden="true">
+                    <Play size={28} fill="currentColor" />
+                  </span>
+                </button>
+              )}
             </div>
-          ) : null}
+
+            <h3 className={styles.activeVideoTitle}>{activeVideo.title}</h3>
+          </div>
+
+          <ol className={styles.videoPlaylist} aria-label="Performance videos">
+            {videos.map((video, index) => {
+              const isActive = video.id === activeVideo.id;
+
+              return (
+                <li key={video.id}>
+                  <button
+                    type="button"
+                    className={`${styles.playlistItem} ${isActive ? styles.playlistItemActive : ""}`}
+                    aria-current={isActive ? "true" : undefined}
+                    aria-label={`Play ${video.title}`}
+                    onClick={() => playVideo(video)}
+                  >
+                    <span className={styles.playlistThumbnail}>
+                      <Image
+                        src={`https://img.youtube.com/vi/${video.id}/maxresdefault.jpg`}
+                        alt=""
+                        fill
+                        sizes="(max-width: 560px) 35vw, (max-width: 899px) 18vw, 10rem"
+                      />
+                    </span>
+                    <span className={styles.playlistNumber} aria-hidden="true">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <strong>{video.title}</strong>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
         </div>
-      </dialog>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
Closes #29

## Changes

- add four new performance videos and establish the agreed seven-video order
- replace the modal grid with one on-demand privacy-enhanced inline YouTube player
- add a stable seven-item playlist with active state, immediate playback, and responsive scroll-snap navigation
- restyle the section with an open, unboxed presentation while removing the discarded supporting labels

## Validation

- `pnpm lint`
- `pnpm build`
- `git diff --check`

## Docs updated

- Not applicable; the existing README already identifies `src/app/data.json` as the video content source.

## Manual validation

- verified initial load contains no iframe and does not autoplay
- exercised all seven playlist entries and confirmed title, active state, iframe ID, and privacy-enhanced embed URL
- confirmed visible keyboard focus and native player controls
- checked desktop (1440px), tablet (768px), and phone (390px) layouts for overflow, wrapping, and swipe affordance

## Follow-ups

- None.
