### PR TITLE
Build inline homepage video showcase

### DIFF
--- a/src/app/data.json
+++ b/src/app/data.json
@@ -33,9 +33,13 @@
     }
   ],
   "videos": [
+    ["Haven’t We Met", "EuolPrEogoc"],
+    ["In a Sentimental Mood", "6_HX6vTfS-4"],
+    ["Beyond the Sea", "rtxGXTqMXdw"],
+    ["My Funny Valentine", "HTHvkNXp8G4"],
     ["Stella by Starlight", "SRjt5HgpgRM"],
-    ["You Stepped Out Of A Dream", "ee68onP0OHg"],
-    ["The Way You Look Tonight — Medley", "aBUiJQaLWgs"]
+    ["You Stepped Out of a Dream", "ee68onP0OHg"],
+    ["The Way You Look Tonight", "aBUiJQaLWgs"]
   ],
   "social": {
     "youtube": "https://www.youtube.com/user/GaryDacanay",

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -233,7 +233,7 @@
 }
 
 .sectionHeader,
-.videoGrid,
+.videoExperience,
 .forHireShell,
 .footerMain,
 .footerBottom {
@@ -242,12 +242,7 @@
 }
 
 .sectionHeader {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  align-items: end;
-  gap: 3rem;
-  padding-bottom: 2rem;
-  border-bottom: 1px solid var(--color-rule);
+  padding-bottom: 0;
 }
 
 .sectionHeader h2,
@@ -261,169 +256,184 @@
 }
 
 .sectionHeader h2 {
-  font-size: clamp(3.5rem, 7vw, 7.5rem);
+  font-size: clamp(3.5rem, 5vw, 5.5rem);
 }
 
-.videoGrid {
+.videoExperience {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1.25rem;
-  margin-top: 2rem;
+  grid-template-columns: minmax(0, 1.75fr) minmax(20rem, 1fr);
+  gap: clamp(2rem, 4vw, 4rem);
+  align-items: start;
+  margin-top: 2.25rem;
 }
 
-.videoCard {
-  border: 1px solid var(--color-rule);
-  background: var(--color-ink-soft);
+.videoStage,
+.videoPlaylist {
+  min-width: 0;
 }
 
-.videoCard button {
-  display: block;
-  width: 100%;
-  height: 100%;
-  border: 0;
-  padding: 0;
-  color: inherit;
-  background: transparent;
-  text-align: left;
-}
-
-.videoMedia {
+.featuredMedia {
   position: relative;
-  display: block;
   aspect-ratio: 16 / 9;
   overflow: hidden;
+  border-radius: 0.75rem;
   background: #050504;
 }
 
-.videoMedia img {
+.featuredMedia iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.featuredPlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  border: 0;
+  padding: 0;
+  color: var(--color-ink);
+  background: transparent;
+}
+
+.featuredPlay:focus-visible {
+  outline-offset: -4px;
+}
+
+.featuredPlay::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: rgb(11 10 9 / 0.18);
+  transition: background-color 200ms ease;
+}
+
+.featuredPlay img {
   object-fit: cover;
-  filter: saturate(0.55) contrast(1.08) sepia(0.24);
+  filter: saturate(0.65) contrast(1.06) sepia(0.18);
   transition:
     filter 240ms ease,
     transform 360ms ease;
 }
 
-.videoOverlay {
+.featuredPlayIcon {
   position: absolute;
-  inset: 0;
+  inset: 50% auto auto 50%;
+  z-index: 1;
   display: grid;
   place-items: center;
-  color: var(--color-ink);
-  background: rgb(11 10 9 / 0.22);
-  transition: background-color 200ms ease;
-}
-
-.videoOverlay svg {
-  box-sizing: content-box;
-  border: 1px solid rgb(11 10 9 / 0.4);
+  width: 4.5rem;
+  height: 4.5rem;
+  border: 1px solid rgb(11 10 9 / 0.42);
   border-radius: 50%;
-  padding: 1rem;
+  color: var(--color-ink);
   background: var(--color-gold);
-  transition: transform 180ms ease;
+  transform: translate(-50%, -50%);
+  transition:
+    background-color 180ms ease,
+    transform 180ms ease;
 }
 
-.videoCard button:hover .videoMedia img,
-.videoCard button:focus-visible .videoMedia img {
-  filter: saturate(0.82) contrast(1.08) sepia(0.12);
+.featuredPlay:hover img,
+.featuredPlay:focus-visible img {
+  filter: saturate(0.82) contrast(1.06) sepia(0.08);
   transform: scale(1.035);
 }
 
-.videoCard button:hover .videoOverlay,
-.videoCard button:focus-visible .videoOverlay {
+.featuredPlay:hover::after,
+.featuredPlay:focus-visible::after {
   background: rgb(11 10 9 / 0.06);
 }
 
-.videoCard button:hover .videoOverlay svg,
-.videoCard button:focus-visible .videoOverlay svg {
-  transform: scale(1.08);
+.featuredPlay:hover .featuredPlayIcon,
+.featuredPlay:focus-visible .featuredPlayIcon {
+  background: var(--color-paper);
+  transform: translate(-50%, -50%) scale(1.06);
 }
 
-.videoMeta {
-  display: grid;
-  min-height: 7.25rem;
-  grid-template-columns: auto 1fr;
-  gap: 1rem;
-  align-content: start;
-  padding: 1.2rem;
-  border-top: 1px solid var(--color-rule);
-}
-
-.videoMeta > span:first-child {
-  color: var(--color-rust);
+.activeVideoTitle {
+  max-width: 16ch;
+  margin: 1.25rem 0 0;
   font-family: var(--font-display), sans-serif;
-  font-size: 0.8rem;
-  letter-spacing: 0.1em;
-}
-
-.videoMeta strong {
-  font-family: var(--font-display), sans-serif;
-  font-size: clamp(1.6rem, 2.5vw, 2.6rem);
+  font-size: clamp(2.8rem, 4.4vw, 5rem);
   font-weight: 400;
-  line-height: 0.95;
+  line-height: 0.9;
   letter-spacing: 0.02em;
   text-transform: uppercase;
 }
 
-.videoDialog {
-  width: min(92vw, 72rem);
-  max-width: none;
-  border: 1px solid var(--color-gold);
+.videoPlaylist {
+  display: grid;
+  gap: 0.4rem;
+  margin: -0.45rem 0 0;
   padding: 0;
-  color: var(--color-paper);
-  background: var(--color-ink);
-  box-shadow: 0 2rem 8rem rgb(0 0 0 / 0.72);
+  list-style: none;
 }
 
-.videoDialog::backdrop {
-  background: rgb(0 0 0 / 0.84);
-  backdrop-filter: blur(8px);
-}
-
-.dialogPanel {
+.videoPlaylist li {
   min-width: 0;
 }
 
-.dialogHeader {
-  display: flex;
-  min-height: 4rem;
+.playlistItem {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(7rem, 9.25rem) auto minmax(0, 1fr);
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.8rem 1rem 0.8rem 1.25rem;
-  border-bottom: 1px solid var(--color-rule);
+  gap: 0.8rem;
+  border: 0;
+  border-radius: 0.75rem;
+  padding: 0.45rem;
+  color: var(--color-paper);
+  background: transparent;
+  text-align: left;
+  transition: background-color 160ms ease;
 }
 
-.dialogHeader h3 {
-  margin: 0;
+.playlistItem:hover,
+.playlistItem:focus-visible,
+.playlistItemActive {
+  background: rgb(244 228 184 / 0.07);
+}
+
+.playlistThumbnail {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  background: #050504;
+}
+
+.playlistThumbnail img {
+  object-fit: cover;
+  filter: saturate(0.58) contrast(1.06) sepia(0.18);
+  transition: filter 180ms ease;
+}
+
+.playlistItem:hover .playlistThumbnail img,
+.playlistItem:focus-visible .playlistThumbnail img,
+.playlistItemActive .playlistThumbnail img {
+  filter: saturate(0.82) contrast(1.06) sepia(0.08);
+}
+
+.playlistNumber,
+.playlistItem strong {
   font-family: var(--font-display), sans-serif;
-  font-size: 1.4rem;
   font-weight: 400;
-  letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
-.dialogHeader button {
-  display: inline-flex;
-  width: 2.5rem;
-  height: 2.5rem;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--color-rule);
-  color: var(--color-paper);
-  background: transparent;
+.playlistNumber {
+  color: var(--color-rust);
+  font-size: 1.15rem;
+  letter-spacing: 0.06em;
 }
 
-.videoEmbed {
-  position: relative;
-  aspect-ratio: 16 / 9;
-}
-
-.videoEmbed iframe {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
+.playlistItem strong {
+  font-size: clamp(1.2rem, 1.55vw, 1.65rem);
+  line-height: 0.95;
+  letter-spacing: 0.025em;
 }
 
 .forHire {
@@ -679,12 +689,18 @@
     font-size: clamp(4.5rem, 7.5vw, 6.5rem);
   }
 
-  .videoGrid {
-    gap: 0.8rem;
+  .videoExperience {
+    grid-template-columns: minmax(0, 1.55fr) minmax(19rem, 1fr);
+    gap: 2rem;
   }
 
-  .videoMeta {
-    padding: 1rem;
+  .playlistItem {
+    grid-template-columns: 6.5rem auto minmax(0, 1fr);
+    gap: 0.65rem;
+  }
+
+  .playlistItem strong {
+    font-size: 1.15rem;
   }
 
   .forHireShell,
@@ -791,17 +807,46 @@
     object-position: 50% 13%;
   }
 
-  .sectionHeader {
+  .videoExperience {
     grid-template-columns: 1fr;
-    gap: 1rem;
+    gap: 2rem;
   }
 
-  .videoGrid {
-    grid-template-columns: 1fr;
+  .videoPlaylist {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(15rem, 42vw);
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0.25rem 0.25rem 1rem;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scroll-snap-type: inline mandatory;
+    scrollbar-width: thin;
   }
 
-  .videoMeta {
-    min-height: 6rem;
+  .videoPlaylist::-webkit-scrollbar {
+    height: 0.35rem;
+  }
+
+  .videoPlaylist::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .videoPlaylist::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: rgb(244 228 184 / 0.24);
+  }
+
+  .videoPlaylist li {
+    scroll-snap-align: start;
+  }
+
+  .playlistItem {
+    grid-template-columns: minmax(6.5rem, 43%) auto minmax(0, 1fr);
+  }
+
+  .playlistItem strong {
+    font-size: clamp(1.15rem, 2.8vw, 1.5rem);
   }
 
   .forHireShell,
@@ -877,6 +922,32 @@
 
   .newsletter h2 {
     font-size: clamp(2.9rem, 14vw, 4.2rem);
+  }
+
+  .videoExperience {
+    margin-top: 1.6rem;
+  }
+
+  .featuredMedia {
+    border-radius: 0.625rem;
+  }
+
+  .featuredPlayIcon {
+    width: 4rem;
+    height: 4rem;
+  }
+
+  .activeVideoTitle {
+    margin-top: 1rem;
+    font-size: clamp(2.8rem, 13vw, 4rem);
+  }
+
+  .videoPlaylist {
+    grid-auto-columns: 76vw;
+  }
+
+  .playlistItem {
+    grid-template-columns: 40% auto minmax(0, 1fr);
   }
 
   .serviceGrid {

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -272,6 +272,10 @@
   min-width: 0;
 }
 
+.videoStage {
+  scroll-margin-top: 5.5rem;
+}
+
 .featuredMedia {
   position: relative;
   aspect-ratio: 16 / 9;
@@ -388,6 +392,7 @@
   color: var(--color-paper);
   background: transparent;
   text-align: left;
+  text-decoration: none;
   transition: background-color 160ms ease;
 }
 
@@ -813,40 +818,30 @@
   }
 
   .videoPlaylist {
-    grid-auto-flow: column;
-    grid-auto-columns: minmax(15rem, 42vw);
-    gap: 0.75rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem clamp(1rem, 3vw, 1.5rem);
     margin: 0;
-    padding: 0.25rem 0.25rem 1rem;
-    overflow-x: auto;
-    overscroll-behavior-inline: contain;
-    scroll-snap-type: inline mandatory;
-    scrollbar-width: thin;
-  }
-
-  .videoPlaylist::-webkit-scrollbar {
-    height: 0.35rem;
-  }
-
-  .videoPlaylist::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .videoPlaylist::-webkit-scrollbar-thumb {
-    border-radius: 999px;
-    background: rgb(244 228 184 / 0.24);
-  }
-
-  .videoPlaylist li {
-    scroll-snap-align: start;
+    padding: 0;
   }
 
   .playlistItem {
-    grid-template-columns: minmax(6.5rem, 43%) auto minmax(0, 1fr);
+    height: 100%;
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    align-items: start;
+    gap: 0.75rem 0.65rem;
+    padding: 0.5rem;
+  }
+
+  .playlistThumbnail {
+    grid-column: 1 / -1;
+    width: 100%;
   }
 
   .playlistItem strong {
-    font-size: clamp(1.15rem, 2.8vw, 1.5rem);
+    overflow-wrap: anywhere;
+    font-size: clamp(1.2rem, 2.8vw, 1.5rem);
+    line-height: 1.05;
   }
 
   .forHireShell,
@@ -857,6 +852,44 @@
   .footerConnect {
     border-top: 1px solid var(--color-rule);
     padding-top: 3rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .videoExperience {
+    gap: 1.5rem;
+  }
+
+  .activeVideoTitle {
+    max-width: 20ch;
+    font-size: clamp(2rem, 8vw, 3rem);
+    line-height: 0.95;
+  }
+
+  .videoPlaylist {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+
+  .playlistItem {
+    grid-template-columns: minmax(7rem, 38%) auto minmax(0, 1fr);
+    grid-template-rows: auto;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.45rem;
+  }
+
+  .playlistThumbnail {
+    grid-column: auto;
+  }
+
+  .playlistNumber {
+    font-size: 1rem;
+  }
+
+  .playlistItem strong {
+    font-size: clamp(1.05rem, 4.8vw, 1.3rem);
+    line-height: 1.05;
   }
 }
 
@@ -939,15 +972,6 @@
 
   .activeVideoTitle {
     margin-top: 1rem;
-    font-size: clamp(2.8rem, 13vw, 4rem);
-  }
-
-  .videoPlaylist {
-    grid-auto-columns: 76vw;
-  }
-
-  .playlistItem {
-    grid-template-columns: 40% auto minmax(0, 1fr);
   }
 
   .serviceGrid {

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -359,6 +359,7 @@
 
 .activeVideoTitle {
   max-width: 16ch;
+  min-height: 1.8em;
   margin: 1.25rem 0 0;
   font-family: var(--font-display), sans-serif;
   font-size: clamp(2.8rem, 4.4vw, 5rem);
@@ -366,6 +367,52 @@
   line-height: 0.9;
   letter-spacing: 0.02em;
   text-transform: uppercase;
+}
+
+.skeletonMedia {
+  background: rgb(39 38 35);
+  animation: videoSkeletonPulse 1.6s ease-in-out infinite;
+}
+
+.skeletonTitle {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.25em;
+}
+
+.skeletonTitleLine {
+  display: block;
+  width: min(11ch, 68%);
+  height: 0.16em;
+  border-radius: 999px;
+  background: rgb(244 228 184 / 0.22);
+  animation: videoSkeletonPulse 1.6s ease-in-out infinite;
+}
+
+.skeletonTitleLine:last-child {
+  width: min(7ch, 44%);
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@keyframes videoSkeletonPulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+
+  50% {
+    opacity: 0.82;
+  }
 }
 
 .videoPlaylist {
@@ -862,6 +909,7 @@
 
   .activeVideoTitle {
     max-width: 20ch;
+    min-height: 1.9em;
     font-size: clamp(2rem, 8vw, 3rem);
     line-height: 0.95;
   }
@@ -890,6 +938,13 @@
   .playlistItem strong {
     font-size: clamp(1.05rem, 4.8vw, 1.3rem);
     line-height: 1.05;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeletonMedia,
+  .skeletonTitleLine {
+    animation: none;
   }
 }
 

--- a/src/app/home/HomePage.tsx
+++ b/src/app/home/HomePage.tsx
@@ -1,9 +1,11 @@
 import Image from "next/image";
+import { Suspense } from "react";
 import data from "../data.json";
 import { bookingHref } from "../content";
 import { NavBar } from "./NavBar";
 import { NewsletterForm } from "./NewsletterForm";
 import { Performances } from "./Performances";
+import { PerformancesSkeleton } from "./PerformancesSkeleton";
 import styles from "./HomePage.module.css";
 
 const socialPlatforms = [
@@ -56,7 +58,9 @@ export function HomePage() {
           </div>
         </section>
 
-        <Performances videos={videos} />
+        <Suspense fallback={<PerformancesSkeleton videos={videos} />}>
+          <Performances videos={videos} />
+        </Suspense>
 
         <section id="events" className={styles.forHire} aria-labelledby="events-title">
           <div className={styles.forHireShell}>

--- a/src/app/home/Performances.tsx
+++ b/src/app/home/Performances.tsx
@@ -2,7 +2,13 @@
 
 import Image from "next/image";
 import { Play } from "lucide-react";
-import { useState } from "react";
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import styles from "./HomePage.module.css";
 
 type Video = {
@@ -10,13 +16,123 @@ type Video = {
   id: string;
 };
 
+const videoScrollStateKey = "videoShowcaseScrollY";
+
 export function Performances({ videos }: { videos: Video[] }) {
   const [activeVideo, setActiveVideo] = useState<Video | null>(videos[0] ?? null);
   const [isPlaying, setIsPlaying] = useState(false);
+  const videoStageRef = useRef<HTMLDivElement>(null);
+  const playerFrameRef = useRef<HTMLIFrameElement>(null);
+  const shouldFocusPlayerRef = useRef(false);
 
-  const playVideo = (video: Video) => {
+  useEffect(() => {
+    const syncVideoFromHistory = (event?: PopStateEvent) => {
+      const requestedId = new URL(window.location.href).searchParams.get("watch");
+      const requestedVideo = videos.find((video) => video.id === requestedId);
+      const storedScrollPosition = event?.state?.[videoScrollStateKey];
+
+      setActiveVideo(requestedVideo ?? videos[0] ?? null);
+      setIsPlaying(false);
+      shouldFocusPlayerRef.current = false;
+
+      if (typeof storedScrollPosition === "number") {
+        window.requestAnimationFrame(() => {
+          window.scrollTo({ top: storedScrollPosition, behavior: "auto" });
+        });
+      } else if (requestedVideo) {
+        window.requestAnimationFrame(() => {
+          videoStageRef.current?.scrollIntoView({ behavior: "auto", block: "start" });
+        });
+      }
+    };
+
+    syncVideoFromHistory();
+    window.addEventListener("popstate", syncVideoFromHistory);
+
+    return () => window.removeEventListener("popstate", syncVideoFromHistory);
+  }, [videos]);
+
+  useEffect(() => {
+    if (!isPlaying || !shouldFocusPlayerRef.current) {
+      return;
+    }
+
+    shouldFocusPlayerRef.current = false;
+    playerFrameRef.current?.focus();
+  }, [activeVideo, isPlaying]);
+
+  const watchHref = (video: Video) => `/?watch=${encodeURIComponent(video.id)}#videos`;
+
+  const pushVideoHistory = (video: Video) => {
+    const url = new URL(window.location.href);
+    const isCurrentVideo = url.searchParams.get("watch") === video.id;
+    const currentState = {
+      ...window.history.state,
+      [videoScrollStateKey]: window.scrollY,
+    };
+
+    window.history.replaceState(currentState, "", window.location.href);
+
+    url.searchParams.set("watch", video.id);
+    url.hash = "videos";
+
+    if (isCurrentVideo) {
+      window.history.replaceState(currentState, "", url);
+    } else {
+      window.history.pushState(currentState, "", url);
+    }
+  };
+
+  const playVideo = (video: Video, shouldFocusPlayer = false) => {
+    shouldFocusPlayerRef.current = shouldFocusPlayer;
     setActiveVideo(video);
+    setIsPlaying(false);
+    pushVideoHistory(video);
+
+    if (window.matchMedia("(max-width: 899px)").matches) {
+      videoStageRef.current?.scrollIntoView({ behavior: "auto", block: "start" });
+      window.requestAnimationFrame(() => {
+        window.history.replaceState(
+          {
+            ...window.history.state,
+            [videoScrollStateKey]: window.scrollY,
+          },
+          "",
+          window.location.href,
+        );
+        setIsPlaying(true);
+      });
+      return;
+    }
+
     setIsPlaying(true);
+  };
+
+  const handlePlaylistClick = (event: MouseEvent<HTMLAnchorElement>, video: Video) => {
+    if (
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    playVideo(video, event.detail === 0);
+  };
+
+  const handlePlaylistKeyDown = (
+    event: KeyboardEvent<HTMLAnchorElement>,
+    video: Video,
+  ) => {
+    if (event.key !== "Enter") {
+      return;
+    }
+
+    event.preventDefault();
+    playVideo(video, true);
   };
 
   return (
@@ -27,12 +143,13 @@ export function Performances({ videos }: { videos: Video[] }) {
 
       {activeVideo ? (
         <div className={styles.videoExperience}>
-          <div className={styles.videoStage}>
+          <div ref={videoStageRef} className={styles.videoStage}>
             <div className={styles.featuredMedia}>
               {isPlaying ? (
                 <iframe
+                  ref={playerFrameRef}
                   key={activeVideo.id}
-                  src={`https://www.youtube-nocookie.com/embed/${activeVideo.id}?autoplay=1&rel=0`}
+                  src={`https://www.youtube-nocookie.com/embed/${activeVideo.id}?autoplay=1&rel=0&playsinline=1`}
                   title={activeVideo.title}
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                   allowFullScreen
@@ -42,7 +159,7 @@ export function Performances({ videos }: { videos: Video[] }) {
                   type="button"
                   className={styles.featuredPlay}
                   aria-label={`Play ${activeVideo.title}`}
-                  onClick={() => setIsPlaying(true)}
+                  onClick={(event) => playVideo(activeVideo, event.detail === 0)}
                 >
                   <Image
                     src={`https://img.youtube.com/vi/${activeVideo.id}/maxresdefault.jpg`}
@@ -66,12 +183,13 @@ export function Performances({ videos }: { videos: Video[] }) {
 
               return (
                 <li key={video.id}>
-                  <button
-                    type="button"
+                  <a
+                    href={watchHref(video)}
                     className={`${styles.playlistItem} ${isActive ? styles.playlistItemActive : ""}`}
                     aria-current={isActive ? "true" : undefined}
                     aria-label={`Play ${video.title}`}
-                    onClick={() => playVideo(video)}
+                    onClick={(event) => handlePlaylistClick(event, video)}
+                    onKeyDown={(event) => handlePlaylistKeyDown(event, video)}
                   >
                     <span className={styles.playlistThumbnail}>
                       <Image
@@ -85,7 +203,7 @@ export function Performances({ videos }: { videos: Video[] }) {
                       {String(index + 1).padStart(2, "0")}
                     </span>
                     <strong>{video.title}</strong>
-                  </button>
+                  </a>
                 </li>
               );
             })}

--- a/src/app/home/Performances.tsx
+++ b/src/app/home/Performances.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Image from "next/image";
-import { Play, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Play } from "lucide-react";
+import { useState } from "react";
 import styles from "./HomePage.module.css";
 
 type Video = {
@@ -11,87 +11,87 @@ type Video = {
 };
 
 export function Performances({ videos }: { videos: Video[] }) {
-  const [activeVideo, setActiveVideo] = useState<Video | null>(null);
-  const dialogRef = useRef<HTMLDialogElement>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [activeVideo, setActiveVideo] = useState<Video | null>(videos[0] ?? null);
+  const [isPlaying, setIsPlaying] = useState(false);
 
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (activeVideo && dialog && !dialog.open) dialog.showModal();
-  }, [activeVideo]);
-
-  const closeModal = () => dialogRef.current?.close();
+  const playVideo = (video: Video) => {
+    setActiveVideo(video);
+    setIsPlaying(true);
+  };
 
   return (
     <section id="videos" className={styles.performances} aria-labelledby="performances-title">
       <div className={styles.sectionHeader}>
-        <div>
-          <h2 id="performances-title">Videos</h2>
-        </div>
+        <h2 id="performances-title">Videos</h2>
       </div>
 
-      <div className={styles.videoGrid}>
-        {videos.map((video, index) => (
-          <article className={styles.videoCard} key={video.id}>
-            <button
-              type="button"
-              aria-label={`Play ${video.title}`}
-              onClick={(event) => {
-                triggerRef.current = event.currentTarget;
-                setActiveVideo(video);
-              }}
-            >
-              <span className={styles.videoMedia}>
-                <Image
-                  src={`https://img.youtube.com/vi/${video.id}/maxresdefault.jpg`}
-                  alt=""
-                  fill
-                  sizes="(max-width: 760px) 100vw, 33vw"
+      {activeVideo ? (
+        <div className={styles.videoExperience}>
+          <div className={styles.videoStage}>
+            <div className={styles.featuredMedia}>
+              {isPlaying ? (
+                <iframe
+                  key={activeVideo.id}
+                  src={`https://www.youtube-nocookie.com/embed/${activeVideo.id}?autoplay=1&rel=0`}
+                  title={activeVideo.title}
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  allowFullScreen
                 />
-                <span className={styles.videoOverlay}>
-                  <Play size={24} fill="currentColor" />
-                </span>
-              </span>
-              <span className={styles.videoMeta}>
-                <span>{String(index + 1).padStart(2, "0")}</span>
-                <strong>{video.title}</strong>
-              </span>
-            </button>
-          </article>
-        ))}
-      </div>
-
-      <dialog
-        ref={dialogRef}
-        className={styles.videoDialog}
-        aria-label={activeVideo ? `Video: ${activeVideo.title}` : "Performance video"}
-        onClick={(event) => {
-          if (event.target === event.currentTarget) closeModal();
-        }}
-        onClose={() => {
-          setActiveVideo(null);
-          requestAnimationFrame(() => triggerRef.current?.focus());
-        }}
-      >
-        <div className={styles.dialogPanel}>
-          <div className={styles.dialogHeader}>
-            <h3>{activeVideo?.title}</h3>
-            <button type="button" onClick={closeModal} aria-label="Close video">
-              <X size={22} />
-            </button>
-          </div>
-          {activeVideo ? (
-            <div className={styles.videoEmbed}>
-              <iframe
-                src={`https://www.youtube-nocookie.com/embed/${activeVideo.id}?autoplay=1&rel=0`}
-                title={activeVideo.title}
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                allowFullScreen
-              />
+              ) : (
+                <button
+                  type="button"
+                  className={styles.featuredPlay}
+                  aria-label={`Play ${activeVideo.title}`}
+                  onClick={() => setIsPlaying(true)}
+                >
+                  <Image
+                    src={`https://img.youtube.com/vi/${activeVideo.id}/maxresdefault.jpg`}
+                    alt=""
+                    fill
+                    sizes="(max-width: 899px) 100vw, 64vw"
+                  />
+                  <span className={styles.featuredPlayIcon} aria-hidden="true">
+                    <Play size={28} fill="currentColor" />
+                  </span>
+                </button>
+              )}
             </div>
-          ) : null}
+
+            <h3 className={styles.activeVideoTitle}>{activeVideo.title}</h3>
+          </div>
+
+          <ol className={styles.videoPlaylist} aria-label="Performance videos">
+            {videos.map((video, index) => {
+              const isActive = video.id === activeVideo.id;
+
+              return (
+                <li key={video.id}>
+                  <button
+                    type="button"
+                    className={`${styles.playlistItem} ${isActive ? styles.playlistItemActive : ""}`}
+                    aria-current={isActive ? "true" : undefined}
+                    aria-label={`Play ${video.title}`}
+                    onClick={() => playVideo(video)}
+                  >
+                    <span className={styles.playlistThumbnail}>
+                      <Image
+                        src={`https://img.youtube.com/vi/${video.id}/maxresdefault.jpg`}
+                        alt=""
+                        fill
+                        sizes="(max-width: 560px) 35vw, (max-width: 899px) 18vw, 10rem"
+                      />
+                    </span>
+                    <span className={styles.playlistNumber} aria-hidden="true">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <strong>{video.title}</strong>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
         </div>
-      </dialog>
+      ) : null}
     </section>
   );
 }

--- a/src/app/home/Performances.tsx
+++ b/src/app/home/Performances.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { Play } from "lucide-react";
+import { useSearchParams } from "next/navigation";
 import {
   type KeyboardEvent,
   type MouseEvent,
@@ -11,7 +12,7 @@ import {
 } from "react";
 import styles from "./HomePage.module.css";
 
-type Video = {
+export type Video = {
   title: string;
   id: string;
 };
@@ -19,14 +20,21 @@ type Video = {
 const videoScrollStateKey = "videoShowcaseScrollY";
 
 export function Performances({ videos }: { videos: Video[] }) {
-  const [activeVideo, setActiveVideo] = useState<Video | null>(videos[0] ?? null);
+  const searchParams = useSearchParams();
+  const requestedVideo = videos.find(
+    (video) => video.id === searchParams.get("watch"),
+  );
+  const initialRequestedVideoRef = useRef(requestedVideo);
+  const [activeVideo, setActiveVideo] = useState<Video | null>(
+    () => requestedVideo ?? videos[0] ?? null,
+  );
   const [isPlaying, setIsPlaying] = useState(false);
   const videoStageRef = useRef<HTMLDivElement>(null);
   const playerFrameRef = useRef<HTMLIFrameElement>(null);
   const shouldFocusPlayerRef = useRef(false);
 
   useEffect(() => {
-    const syncVideoFromHistory = (event?: PopStateEvent) => {
+    const syncVideoFromHistory = (event: PopStateEvent) => {
       const requestedId = new URL(window.location.href).searchParams.get("watch");
       const requestedVideo = videos.find((video) => video.id === requestedId);
       const storedScrollPosition = event?.state?.[videoScrollStateKey];
@@ -46,7 +54,12 @@ export function Performances({ videos }: { videos: Video[] }) {
       }
     };
 
-    syncVideoFromHistory();
+    if (initialRequestedVideoRef.current) {
+      window.requestAnimationFrame(() => {
+        videoStageRef.current?.scrollIntoView({ behavior: "auto", block: "start" });
+      });
+    }
+
     window.addEventListener("popstate", syncVideoFromHistory);
 
     return () => window.removeEventListener("popstate", syncVideoFromHistory);

--- a/src/app/home/PerformancesSkeleton.tsx
+++ b/src/app/home/PerformancesSkeleton.tsx
@@ -1,0 +1,67 @@
+import Image from "next/image";
+import type { Video } from "./Performances";
+import styles from "./HomePage.module.css";
+
+const watchHref = (video: Video) =>
+  `/?watch=${encodeURIComponent(video.id)}#videos`;
+
+export function PerformancesSkeleton({ videos }: { videos: Video[] }) {
+  return (
+    <section
+      id="videos"
+      className={styles.performances}
+      aria-labelledby="performances-title"
+      aria-busy="true"
+    >
+      <span className={styles.visuallyHidden} role="status">
+        Loading selected video
+      </span>
+
+      <div className={styles.sectionHeader}>
+        <h2 id="performances-title">Videos</h2>
+      </div>
+
+      <div className={styles.videoExperience}>
+        <div className={styles.videoStage}>
+          <div
+            className={`${styles.featuredMedia} ${styles.skeletonMedia}`}
+            aria-hidden="true"
+          />
+
+          <h3
+            className={`${styles.activeVideoTitle} ${styles.skeletonTitle}`}
+            aria-hidden="true"
+          >
+            <span className={styles.skeletonTitleLine} />
+            <span className={styles.skeletonTitleLine} />
+          </h3>
+        </div>
+
+        <ol className={styles.videoPlaylist} aria-label="Performance videos">
+          {videos.map((video, index) => (
+            <li key={video.id}>
+              <a
+                href={watchHref(video)}
+                className={styles.playlistItem}
+                aria-label={`Play ${video.title}`}
+              >
+                <span className={styles.playlistThumbnail}>
+                  <Image
+                    src={`https://img.youtube.com/vi/${video.id}/maxresdefault.jpg`}
+                    alt=""
+                    fill
+                    sizes="(max-width: 560px) 35vw, (max-width: 899px) 18vw, 10rem"
+                  />
+                </span>
+                <span className={styles.playlistNumber} aria-hidden="true">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <strong>{video.title}</strong>
+              </a>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #29

Supersedes #30. This replacement branch is based directly on the latest `2026_07` branch.

## Changes

- add four new performance videos and establish the agreed seven-video order
- replace the modal grid with one deferred privacy-enhanced inline YouTube player
- add URL-backed video selection with shareable `?watch=<youtube-id>#videos` links and Back/Forward history
- restore the visitor's exact playlist position when navigating back
- keep the desktop player/rail layout, introduce a two-column tablet grid, and use compact vertical rows on phones
- remove horizontal scroll-snap navigation and add inline mobile playback with `playsinline=1`
- preserve full keyboard activation, visible focus, `aria-current`, iframe titles, and native fullscreen controls
- wrap only the URL-dependent video experience in Suspense so the homepage remains statically generated
- server-render the real heading and seven functional playlist links while skeletonizing only the featured media and title
- derive the initial selection synchronously from `useSearchParams` to prevent the default-video flash
- reserve a consistent two-line title area and disable the restrained skeleton pulse under reduced motion

## Validation

- `pnpm lint`
- `pnpm build` — confirms `/` remains statically prerendered
- `git diff --check`
- inspected production HTML for the loading status, all seven watch links, no iframe, no `aria-current`, and no resolved title
- verified base, valid-watch, and invalid-watch production URLs resolve to the expected paused selection

## Docs updated

- Not applicable; the existing README already identifies `src/app/data.json` as the video content source.

## Manual validation

- verified responsive behavior at 1440px, 900/899px, 768px, 641/640px, and 390px
- confirmed initial and history-driven loads contain no iframe and do not autoplay
- exercised all seven entries and confirmed URL, selected title, active state, iframe ID, and privacy-enhanced embed parameters
- verified direct watch links, invalid-ID fallback, Back/Forward selection, and exact scroll-position restoration
- confirmed keyboard activation transfers focus into the iframe and native fullscreen controls remain available
- confirmed no horizontal page overflow at any tested breakpoint

## Follow-ups

- None currently.
