### PR TITLE
Redesign mobile navigation overlay

### DIFF
--- a/src/app/data.json
+++ b/src/app/data.json
@@ -8,7 +8,7 @@
   },
   "navigation": [
     { "label": "Videos", "href": "#videos" },
-    { "label": "Photographs", "href": "#photographs" },
+    { "label": "Photos", "href": "#photographs" },
     { "label": "Events", "href": "#events" }
   ],
   "booking": {

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -112,6 +112,10 @@
   display: none;
 }
 
+.mobileNavigationLinks {
+  display: contents;
+}
+
 .hero {
   position: relative;
   min-height: 100svh;
@@ -978,12 +982,11 @@
     display: flex;
     visibility: hidden;
     flex-direction: column;
-    justify-content: center;
-    gap: 0.25rem;
-    padding: 6rem 1.25rem 2rem;
-    background:
-      radial-gradient(circle at 82% 24%, rgb(169 87 58 / 0.2), transparent 18rem),
-      var(--color-ink);
+    padding: 7.75rem clamp(1.5rem, 7vw, 2.5rem) max(1.5rem, env(safe-area-inset-bottom));
+    overflow-y: auto;
+    background: rgb(8 7 6 / 0.88);
+    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(18px);
     opacity: 0;
     transform: translateY(-1rem);
     transition:
@@ -999,23 +1002,50 @@
     transition-delay: 0s;
   }
 
-  .mobileNavigation a {
-    display: block;
-    border-bottom: 1px solid var(--color-rule);
-    padding: 0.7rem 0;
-    font-family: var(--font-display), sans-serif;
-    font-size: clamp(2.8rem, 12vw, 5rem);
-    line-height: 0.9;
-    text-transform: uppercase;
+  .mobileNavigationLinks {
+    position: relative;
+    display: flex;
+    align-self: start;
+    flex-direction: column;
+    gap: clamp(1.15rem, 3.2svh, 1.65rem);
+    padding-top: clamp(0.75rem, 5svh, 3rem);
   }
 
-  .mobileBooking {
-    margin-top: 1.5rem;
-    border: 1px solid var(--color-gold) !important;
-    padding: 1rem !important;
-    color: var(--color-ink);
-    background: var(--color-gold);
-    text-align: center;
+  .mobileNavigation a {
+    display: block;
+    padding: 0.18rem 0;
+    font-family: var(--font-display), sans-serif;
+    font-size: clamp(3.7rem, 15vw, 4.7rem);
+    line-height: 0.82;
+    letter-spacing: -0.02em;
+    text-transform: uppercase;
+    transition: color 160ms ease;
+  }
+
+  .mobileNavigationLinks a:hover,
+  .mobileNavigationLinks a:focus-visible {
+    color: var(--color-gold);
+  }
+
+  @media (max-height: 44rem) {
+    .mobileNavigation {
+      padding-top: 5.9rem;
+    }
+
+    .mobileNavigationLinks {
+      gap: 0.8rem;
+      padding-top: 0.4rem;
+    }
+
+    .mobileNavigation a {
+      font-size: clamp(3.3rem, 14vw, 4rem);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mobileNavigation {
+      transition: none;
+    }
   }
 
   .hero {

--- a/src/app/home/NavBar.tsx
+++ b/src/app/home/NavBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Menu, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "./HomePage.module.css";
 
 type NavigationItem = {
@@ -20,6 +20,8 @@ export function NavBar({
 }) {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const mobileNavigationRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     const update = () => setScrolled(window.scrollY > 24);
@@ -32,18 +34,53 @@ export function NavBar({
     if (!open) return;
 
     const previousOverflow = document.body.style.overflow;
+    const menuButton = menuButtonRef.current;
     const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
+      if (event.key === "Escape") {
+        setOpen(false);
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusableItems = mobileNavigationRef.current?.querySelectorAll<HTMLElement>(
+        'a[href]',
+      );
+      if (!focusableItems?.length) return;
+
+      const firstItem = focusableItems[0];
+      const lastItem = focusableItems[focusableItems.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstItem) {
+        event.preventDefault();
+        lastItem.focus();
+      } else if (!event.shiftKey && document.activeElement === lastItem) {
+        event.preventDefault();
+        firstItem.focus();
+      }
     };
 
     document.body.style.overflow = "hidden";
     window.addEventListener("keydown", closeOnEscape);
+    window.requestAnimationFrame(() => {
+      mobileNavigationRef.current?.querySelector<HTMLElement>('a[href]')?.focus();
+    });
 
     return () => {
       document.body.style.overflow = previousOverflow;
       window.removeEventListener("keydown", closeOnEscape);
+      menuButton?.focus({ preventScroll: true });
     };
   }, [open]);
+
+  useEffect(() => {
+    const closeOnDesktop = () => {
+      if (window.matchMedia("(min-width: 900px)").matches) setOpen(false);
+    };
+
+    window.addEventListener("resize", closeOnDesktop);
+    return () => window.removeEventListener("resize", closeOnDesktop);
+  }, []);
 
   return (
     <header className={`${styles.nav} ${scrolled ? styles.navScrolled : ""}`}>
@@ -65,6 +102,7 @@ export function NavBar({
       <button
         type="button"
         className={styles.menuButton}
+        ref={menuButtonRef}
         aria-expanded={open}
         aria-controls="mobile-navigation"
         aria-label={open ? "Close navigation" : "Open navigation"}
@@ -75,18 +113,18 @@ export function NavBar({
 
       <nav
         id="mobile-navigation"
+        ref={mobileNavigationRef}
         className={`${styles.mobileNavigation} ${open ? styles.mobileNavigationOpen : ""}`}
         aria-label="Mobile navigation"
         aria-hidden={!open}
       >
-        {navigation.map((item) => (
-          <a key={item.href} href={item.href} onClick={() => setOpen(false)}>
-            {item.label}
-          </a>
-        ))}
-        <a className={styles.mobileBooking} href={bookingHref} onClick={() => setOpen(false)}>
-          Check availability
-        </a>
+        <div className={styles.mobileNavigationLinks}>
+          {navigation.map((item) => (
+            <a key={item.href} href={item.href} onClick={() => setOpen(false)}>
+              {item.label}
+            </a>
+          ))}
+        </div>
       </nav>
     </header>
   );

--- a/src/app/home/PhotoGallery.tsx
+++ b/src/app/home/PhotoGallery.tsx
@@ -143,7 +143,7 @@ export function PhotoGallery() {
     >
       <div className={styles.photoGallery}>
         <div className={styles.photoHeader}>
-          <h2 id="photographs-title">Photographs</h2>
+          <h2 id="photographs-title">Photos</h2>
           <button
             type="button"
             className={styles.photoOpenButton}


### PR DESCRIPTION
Closes #32\n\n## Changes\n- Redesign the mobile menu as a full-screen loose navigation stack.\n- Remove the mobile availability CTA and menu-specific background image.\n- Use a translucent near-black, blurred backdrop.\n- Rename the navigation and gallery heading from Photographs to Photos.\n- Add focus handling, scroll locking, Escape close, and reduced-motion support.\n\n## Validation\n- \n- ▲ Next.js 16.2.0 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 869ms
  Running TypeScript ...
  Finished TypeScript in 1029ms ...
  Collecting page data using 5 workers ...
  Generating static pages using 5 workers (0/4) ...
  Generating static pages using 5 workers (1/4) 
  Generating static pages using 5 workers (2/4) 
  Generating static pages using 5 workers (3/4) 
✓ Generating static pages using 5 workers (4/4) in 179ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
└ ○ /_not-found


○  (Static)  prerendered as static content\n\n## Docs updated\n- Not needed; this is a visual and interaction refinement.\n\n## Manual validation\n- Responsive browser automation could not reach the existing local server from its isolated browser surface.\n\n## Follow-up\n- Add Music only after its site section exists.