### PR TITLE
Improve music release preview

### DIFF
--- a/docs/music-releases.md
+++ b/docs/music-releases.md
@@ -1,26 +1,23 @@
 # Music releases
 
-This document records the intended music-release experience for the website.
-It is guidance for future implementation, not a description of functionality
-that is currently live.
+This document records the music-release experience for the website. Phase 1 is
+live; later phases are guidance for future implementation.
 
 ## Decision
 
-Use a progressive hybrid experience:
+Use a progressive, platform-neutral experience:
 
 - Present releases with custom website-native artwork, titles, dates, copy, and
   calls to action.
-- Load an official Spotify embed only after a visitor chooses to listen.
-- Allow only one release embed to be active at a time.
-- Add one official Spotify discography-playlist embed after the catalog is large
-  enough for the playlist to feel useful.
-- Keep Spotify URLs optional so unreleased music and the not-yet-created
-  playlist do not produce empty or disabled interface elements.
+- Link to each available listening platform from each release.
+- Keep platform URLs optional so unreleased music and unavailable platforms do
+  not produce empty or disabled interface elements.
+- Consider embeds or playlist destinations later only when there is a clear
+  promotional need.
 
-This approach keeps the page visually consistent, avoids loading a player for
-every release, and delegates playback and availability behavior to Spotify. It
-also avoids the authentication, credentials, quotas, and operational overhead
-of the Spotify Web API and Web Playback SDK.
+This approach keeps the page visually consistent, treats supported platforms
+equally, avoids loading third-party players, and delegates playback and
+availability behavior to the listening services.
 
 ## Staged rollout
 
@@ -28,10 +25,10 @@ of the Spotify Web API and Web Playback SDK.
 
 - Treat the single as a featured release instead of showing a sparse grid.
 - Show artwork, title, release date, and brief supporting copy in regular HTML.
-- Provide a **Listen now** action that creates or reveals the official Spotify
-  track or album embed.
-- Provide a separate **Open in Spotify** link.
-- Do not render a playlist section or an empty discography state.
+- Provide equal **Listen on Spotify** and **Listen on Apple Music** links when
+  those services are available.
+- Do not render an embedded player, playlist section, or empty discography
+  state.
 
 ### Phase 2: an upcoming second single
 
@@ -40,38 +37,36 @@ of the Spotify Web API and Web Playback SDK.
   public.
 - Link to a pre-save or platform-neutral release page when one exists.
 - Do not show an inactive play control for music that cannot yet be played.
-- Change the release to `released` and add its Spotify URL when it becomes
-  available.
+- Change the release to `released` and add the available platform URLs when it
+  becomes available.
 
 ### Phase 3: multiple released singles
 
 - Keep the newest or editorially selected release featured.
 - Present the remaining releases as website-native cards.
-- Reuse one player region: selecting another release replaces the current
-  Spotify embed.
 - Prefer a small grid for a short catalog; revisit navigation only after the
   collection becomes large enough to require it.
 
 ### Phase 4: discography playlist
 
-- Create an artist-owned Spotify playlist with a durable name that is not tied
-  to one campaign.
+- Create artist-owned playlists in the selected services with durable names
+  that are not tied to one campaign.
 - Keep the newest release first unless the artist chooses a deliberate sequence.
-- Add the playlist URL to site content and render one **Listen to all releases**
-  embed.
-- Maintain the playlist in Spotify. Its stable URL lets new additions appear on
-  the website without a deployment.
+- Add the playlist URLs to site content and render matching **Listen to all
+  releases** links.
+- Maintain the playlists in their respective services. Their stable URLs let
+  new additions appear on the website without a deployment.
 - Keep custom cards focused on new or notable releases instead of duplicating
-  every playlist item.
+  each playlist item.
 
-The playlist section should remain hidden until a playlist URL is configured.
-Two tracks can form a playlist, but waiting for roughly three or four releases
-will usually make it a more useful destination.
+The playlist links should remain hidden until at least one playlist URL is
+configured. Two tracks can form a playlist, but waiting for roughly three or
+four releases will usually make it a more useful destination.
 
 ## Proposed content model
 
 Keep release information in the repository while the catalog is small. A CMS
-or Spotify API integration is not warranted unless release updates become
+or platform API integration is not warranted unless release updates become
 frequent or need to be managed by a non-developer.
 
 The eventual content shape should support released and announced music without
@@ -86,6 +81,7 @@ type MusicRelease = {
   status: "upcoming" | "released";
   description?: string;
   spotifyUrl?: string;
+  appleMusicUrl?: string;
   preSaveUrl?: string;
   featured?: boolean;
 };
@@ -93,44 +89,36 @@ type MusicRelease = {
 type MusicContent = {
   releases: MusicRelease[];
   spotifyPlaylistUrl?: string;
+  appleMusicPlaylistUrl?: string;
 };
 ```
 
 The exact representation may be adapted to the existing `src/app/data.json`
 content structure during implementation. Preserve these behaviors:
 
-- `spotifyUrl` is optional for upcoming releases.
+- `spotifyUrl` and `appleMusicUrl` are optional for upcoming releases.
 - `preSaveUrl` is optional and must not be presented as playback.
-- `spotifyPlaylistUrl` is optional and controls whether the playlist section is
-  rendered.
+- `spotifyPlaylistUrl` and `appleMusicPlaylistUrl` are optional and control
+  whether the corresponding playlist links are rendered.
 - `featured` is an editorial choice rather than an assumption based only on
   release date.
 
 ## Interaction and presentation requirements
 
 - Use **Music** or **Releases** as the section name rather than naming the whole
-  section after Spotify. This leaves room for Apple Music, YouTube Music,
-  Bandcamp, or a platform-neutral listening page later.
-- Use a visitor-initiated **Listen now** action. Do not autoplay music.
-- Lazy-load the Spotify embed or create it after interaction.
-- Keep release names, dates, descriptions, and actions outside the iframe so
-  they remain accessible and discoverable before playback loads.
-- Give every iframe a specific, human-readable `title`.
-- Make the player responsive and preserve a usable fallback link to Spotify.
-- Use artwork supplied or approved by the artist for website-native cards. If
-  artwork or metadata is obtained from Spotify, follow Spotify's attribution
-  and design requirements.
-- Do not imitate Spotify controls or host Spotify audio directly.
+  section after one service. This leaves room for future platforms.
+- Keep release names, dates, descriptions, and actions in regular HTML.
+- Give each available platform equal visual weight.
+- Use artwork supplied or approved by the artist for website-native cards.
+- Do not imitate platform controls or host platform audio directly.
 
 ## Analytics
 
-Track website-owned actions rather than relying on events inside the Spotify
-iframe:
+Track website-owned actions:
 
-- Opening the embedded player.
 - Selecting a release.
-- Following an **Open in Spotify** link.
-- Following a pre-save or other listening-platform link.
+- Following each listening-platform link.
+- Following a pre-save link.
 
 Name analytics events by intent and include the release slug and destination as
 properties. Do not block listening if analytics fails or is declined.
@@ -141,36 +129,35 @@ properties. Do not block listening if analytics fails or is declined.
 
 - Confirm which title, artwork, date, and supporting copy are public.
 - Add an `upcoming` release entry.
-- Add a pre-save or platform-neutral link only when it is active.
+- Add a pre-save or platform link only when it is active.
 - Confirm that unreleased controls do not imply playback is available.
 
 ### On release day
 
 - Change the status to `released`.
-- Add and test the canonical Spotify track or album URL.
+- Add and test the canonical Spotify and Apple Music track or album URLs.
 - Decide whether the new release should be featured.
-- Add the release to the discography playlist when that playlist exists.
-- Verify keyboard interaction, responsive layout, the fallback Spotify link,
-  and analytics events.
+- Add the release to each discography playlist when it exists.
+- Verify keyboard interaction, responsive layout, platform links, and analytics
+  events.
 
 ### After release
 
-- Confirm the playlist ordering in Spotify.
+- Confirm the playlist ordering in each service.
 - Remove stale pre-save messaging.
-- Check that only one embed loads or plays at a time.
+- Check that each available platform link remains current.
 
-## Spotify implementation notes
+## Platform integration notes
 
-Prefer Spotify's official iframe embed for playback. The direct embed and the
-Spotify iFrame API are documented at:
+Use canonical, direct links for the curated catalog. If an embedded player is
+reconsidered later, use the service's official player rather than recreating
+its controls or hosting audio directly.
 
 - [Spotify Embeds](https://developer.spotify.com/documentation/embeds)
-- [Using the iFrame API](https://developer.spotify.com/documentation/embeds/tutorials/using-the-iframe-api)
 - [Spotify design and branding guidelines](https://developer.spotify.com/documentation/design)
+- [Apple Music API](https://developer.apple.com/documentation/applemusicapi)
 
-Do not introduce the Spotify Web API merely to render this small, curated
-catalog. Reconsider it only if the site later needs automated discovery or
-metadata synchronization that cannot be handled through the playlist embed and
-repository content. The Web Playback SDK is also out of scope for this
-promotional site because it adds user authentication, Premium-account, browser,
-and policy constraints without improving the planned experience.
+Do not introduce a platform API merely to render this small, curated catalog.
+Reconsider one only if the site later needs automated discovery or metadata
+synchronization that cannot be handled through repository content and curated
+playlist links.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,9 @@ const nextConfig = {
       {
         hostname: "img.youtube.com",
       },
+      {
+        hostname: "image-cdn-fa.spotifycdn.com",
+      },
     ],
   },
 };

--- a/src/app/data.json
+++ b/src/app/data.json
@@ -7,6 +7,7 @@
     "supportingCopy": "Timeless jazz for concerts, weddings, dinners, and private events."
   },
   "navigation": [
+    { "label": "Music", "href": "#music" },
     { "label": "Videos", "href": "#videos" },
     { "label": "Photographs", "href": "#photographs" },
     { "label": "Events", "href": "#events" }
@@ -49,6 +50,17 @@
   },
   "music": {
     "spotify": "https://open.spotify.com/artist/3oPJs0JJuqfXPv4VEkPlAz",
-    "apple_music": "https://music.apple.com/us/artist/gary-dacanay/448384631"
+    "apple_music": "https://music.apple.com/us/artist/gary-dacanay/448384631",
+    "releases": [
+      {
+        "slug": "i-fall-in-love-too-easily",
+        "title": "I Fall In Love Too Easily",
+        "artwork": "https://image-cdn-fa.spotifycdn.com/image/ab67616d00001e021589ff3a3c093be46da9f39f",
+        "status": "released",
+        "description": "Available now on Spotify.",
+        "spotifyUrl": "https://open.spotify.com/track/0hVgBYKeDdVtdoeqMDM7dm",
+        "featured": true
+      }
+    ]
   }
 }

--- a/src/app/data.json
+++ b/src/app/data.json
@@ -57,8 +57,8 @@
         "title": "I Fall In Love Too Easily",
         "artwork": "https://image-cdn-fa.spotifycdn.com/image/ab67616d00001e021589ff3a3c093be46da9f39f",
         "status": "released",
-        "description": "Available now on Spotify.",
         "spotifyUrl": "https://open.spotify.com/track/0hVgBYKeDdVtdoeqMDM7dm",
+        "appleMusicUrl": "https://music.apple.com/us/album/i-fall-in-love-too-easily/6765926775?i=6765926776",
         "featured": true
       }
     ]

--- a/src/app/home/HomePage.tsx
+++ b/src/app/home/HomePage.tsx
@@ -4,6 +4,7 @@ import data from "../data.json";
 import { bookingHref } from "../content";
 import { NavBar } from "./NavBar";
 import { NewsletterForm } from "./NewsletterForm";
+import { MusicSection } from "./MusicSection";
 import { PhotoGallery } from "./PhotoGallery";
 import { Performances } from "./Performances";
 import { PerformancesSkeleton } from "./PerformancesSkeleton";
@@ -58,6 +59,8 @@ export function HomePage() {
             </div>
           </div>
         </section>
+
+        <MusicSection releases={data.music.releases} />
 
         <Suspense fallback={<PerformancesSkeleton videos={videos} />}>
           <Performances videos={videos} />

--- a/src/app/home/MusicSection.module.css
+++ b/src/app/home/MusicSection.module.css
@@ -13,15 +13,7 @@
   margin-inline: auto;
 }
 
-.heading {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.eyebrow,
-.releaseType {
+.listenOn > p {
   margin: 0;
   color: var(--color-gold);
   font-family: var(--font-display), sans-serif;
@@ -30,7 +22,7 @@
   text-transform: uppercase;
 }
 
-.heading h2,
+.title,
 .release h3 {
   margin: 0;
   font-family: var(--font-display), sans-serif;
@@ -39,20 +31,20 @@
   text-transform: uppercase;
 }
 
-.heading h2 {
+.title {
   font-size: clamp(3.5rem, 5vw, 5.5rem);
 }
 
 .release {
   display: grid;
-  grid-template-columns: minmax(16rem, 26rem) minmax(0, 1fr);
-  gap: clamp(2rem, 6vw, 7rem);
+  grid-template-columns: minmax(12rem, 18rem) minmax(0, 1fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
   align-items: center;
-  width: min(100%, 70rem);
-  margin-top: clamp(2rem, 4vw, 3.5rem);
+  width: min(100%, 62rem);
+  margin-top: 2.25rem;
 }
 
-.artworkLink {
+.artworkFrame {
   position: relative;
   display: block;
   aspect-ratio: 1;
@@ -70,99 +62,56 @@
 }
 
 .release h3 {
-  max-width: 12ch;
-  margin-top: 0.6rem;
-  font-size: clamp(3.4rem, 6vw, 6.8rem);
+  max-width: 16ch;
+  font-size: clamp(2.8rem, 4.4vw, 5rem);
 }
 
-.description {
-  margin: 1.3rem 0 0;
-  color: var(--color-paper-muted);
-  font-family: var(--font-serif), Georgia, serif;
-  font-size: clamp(1.3rem, 2vw, 1.7rem);
-  font-style: italic;
-  line-height: 1.25;
+.listenOn {
+  margin-top: 1.35rem;
 }
 
-.actions {
+.platformLinks {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 0.9rem 1.25rem;
-  margin-top: 1.8rem;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
 }
 
-.listenButton,
-.spotifyLink {
+.platformLink {
   display: inline-flex;
   min-height: 3.35rem;
   align-items: center;
   justify-content: center;
   gap: 0.55rem;
+  border: 1px solid var(--color-gold);
+  padding: 0.9rem 1.25rem;
+  color: var(--color-paper);
   font-family: var(--font-display), sans-serif;
   font-size: 1rem;
   letter-spacing: 0.13em;
   line-height: 1;
   text-transform: uppercase;
-}
-
-.listenButton {
-  border: 1px solid var(--color-gold);
-  padding: 0.9rem 1.25rem;
-  color: var(--color-ink);
-  background: var(--color-gold);
   transition:
     color 160ms ease,
     background-color 160ms ease,
     transform 160ms ease;
 }
 
-.listenButton:hover:not(:disabled),
-.listenButton:focus-visible:not(:disabled) {
+.platformLink:hover,
+.platformLink:focus-visible {
   color: var(--color-ink);
   background: var(--color-paper);
   transform: translateY(-2px);
 }
 
-.listenButton:disabled {
-  cursor: wait;
-  opacity: 0.72;
-}
-
-.spotifyLink {
-  border-bottom: 1px solid var(--color-gold);
-  padding: 0.3rem 0;
-  color: var(--color-paper);
-  transition:
-    border-color 160ms ease,
-    color 160ms ease;
-}
-
-.spotifyLink:hover,
-.spotifyLink:focus-visible {
-  border-color: var(--color-paper);
-  color: var(--color-gold);
-}
-
-.spotifyLink img {
+.platformLink img {
   object-fit: contain;
-}
-
-.player {
-  width: min(100%, 34rem);
-  margin-top: 1.75rem;
-}
-
-.player iframe {
-  display: block;
-  border: 0;
-  border-radius: 0.75rem;
 }
 
 @media (max-width: 899px) {
   .release {
-    grid-template-columns: minmax(0, 22rem) minmax(0, 1fr);
-    gap: clamp(1.5rem, 4vw, 3rem);
+    grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr);
+    gap: clamp(1.25rem, 3vw, 2.5rem);
   }
 }
 
@@ -171,20 +120,15 @@
     padding-block: 4.5rem;
   }
 
-  .heading {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
   .release {
     grid-template-columns: 1fr;
   }
 
-  .artworkLink {
-    width: min(100%, 26rem);
+  .artworkFrame {
+    width: min(100%, 18rem);
   }
 
   .release h3 {
-    font-size: clamp(3.4rem, 16vw, 5rem);
+    font-size: clamp(2.8rem, 13vw, 4.4rem);
   }
 }

--- a/src/app/home/MusicSection.module.css
+++ b/src/app/home/MusicSection.module.css
@@ -3,23 +3,14 @@
   padding: clamp(5rem, 9vw, 9rem) clamp(1rem, 4vw, 4rem);
   border-top: 1px solid var(--color-rule);
   background:
-    radial-gradient(circle at 76% 42%, rgb(169 87 58 / 0.2), transparent 24rem),
-    var(--color-ink-soft);
+    radial-gradient(circle at 8% 12%, rgb(82 124 120 / 0.18), transparent 22rem),
+    var(--color-ink);
   scroll-margin-top: 4.8rem;
 }
 
 .shell {
   width: min(100%, var(--container));
   margin-inline: auto;
-}
-
-.listenOn > p {
-  margin: 0;
-  color: var(--color-gold);
-  font-family: var(--font-display), sans-serif;
-  font-size: 0.88rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
 }
 
 .title,
@@ -37,11 +28,12 @@
 
 .release {
   display: grid;
-  grid-template-columns: minmax(12rem, 18rem) minmax(0, 1fr);
-  gap: clamp(1.5rem, 4vw, 4rem);
-  align-items: center;
-  width: min(100%, 62rem);
+  grid-template-columns: 1fr;
+  width: min(100%, 23rem);
   margin-top: 2.25rem;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: var(--color-ink-soft);
 }
 
 .artworkFrame {
@@ -58,16 +50,16 @@
 }
 
 .releaseDetails {
-  max-width: 41rem;
+  padding: 1.1rem 0.35rem 0.35rem;
 }
 
 .release h3 {
-  max-width: 16ch;
-  font-size: clamp(2.8rem, 4.4vw, 5rem);
+  max-width: none;
+  font-size: clamp(2.35rem, 3vw, 3.5rem);
 }
 
 .listenOn {
-  margin-top: 1.35rem;
+  margin-top: 0.85rem;
 }
 
 .platformLinks {
@@ -79,12 +71,12 @@
 
 .platformLink {
   display: inline-flex;
-  min-height: 3.35rem;
+  min-height: 2.8rem;
   align-items: center;
   justify-content: center;
   gap: 0.55rem;
-  border: 1px solid var(--color-gold);
-  padding: 0.9rem 1.25rem;
+  border-bottom: 1px solid var(--color-rule);
+  padding: 0.3rem 0;
   color: var(--color-paper);
   font-family: var(--font-display), sans-serif;
   font-size: 1rem;
@@ -99,20 +91,12 @@
 
 .platformLink:hover,
 .platformLink:focus-visible {
-  color: var(--color-ink);
-  background: var(--color-paper);
-  transform: translateY(-2px);
+  border-color: var(--color-paper);
+  color: var(--color-gold);
 }
 
 .platformLink img {
   object-fit: contain;
-}
-
-@media (max-width: 899px) {
-  .release {
-    grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr);
-    gap: clamp(1.25rem, 3vw, 2.5rem);
-  }
 }
 
 @media (max-width: 640px) {
@@ -121,14 +105,46 @@
   }
 
   .release {
-    grid-template-columns: 1fr;
+    grid-template-columns: 5.5rem minmax(0, 1fr);
+    gap: 0.75rem;
+    align-items: center;
+    width: 100%;
+    padding: 0.75rem;
   }
 
   .artworkFrame {
-    width: min(100%, 18rem);
+    width: 5.5rem;
+  }
+
+  .releaseDetails {
+    min-width: 0;
+    align-self: center;
+    padding: 0;
   }
 
   .release h3 {
-    font-size: clamp(2.8rem, 13vw, 4.4rem);
+    font-size: clamp(1.7rem, 7vw, 2rem);
+  }
+
+  .listenOn {
+    margin-top: 0.5rem;
+  }
+
+  .platformLinks {
+    gap: 0.75rem;
+    margin-top: 0;
+  }
+
+  .platformLink {
+    min-height: auto;
+    padding: 0.2rem 0;
+    font-size: 0.8rem;
+    letter-spacing: 0.09em;
+    white-space: nowrap;
+  }
+
+  .platformLink img {
+    width: 1rem;
+    height: 1rem;
   }
 }

--- a/src/app/home/MusicSection.module.css
+++ b/src/app/home/MusicSection.module.css
@@ -1,0 +1,190 @@
+.music {
+  position: relative;
+  padding: clamp(5rem, 9vw, 9rem) clamp(1rem, 4vw, 4rem);
+  border-top: 1px solid var(--color-rule);
+  background:
+    radial-gradient(circle at 76% 42%, rgb(169 87 58 / 0.2), transparent 24rem),
+    var(--color-ink-soft);
+  scroll-margin-top: 4.8rem;
+}
+
+.shell {
+  width: min(100%, var(--container));
+  margin-inline: auto;
+}
+
+.heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.eyebrow,
+.releaseType {
+  margin: 0;
+  color: var(--color-gold);
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.88rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.heading h2,
+.release h3 {
+  margin: 0;
+  font-family: var(--font-display), sans-serif;
+  font-weight: 400;
+  line-height: 0.88;
+  text-transform: uppercase;
+}
+
+.heading h2 {
+  font-size: clamp(3.5rem, 5vw, 5.5rem);
+}
+
+.release {
+  display: grid;
+  grid-template-columns: minmax(16rem, 26rem) minmax(0, 1fr);
+  gap: clamp(2rem, 6vw, 7rem);
+  align-items: center;
+  width: min(100%, 70rem);
+  margin-top: clamp(2rem, 4vw, 3.5rem);
+}
+
+.artworkLink {
+  position: relative;
+  display: block;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  background: var(--color-ink);
+}
+
+.artwork {
+  object-fit: cover;
+}
+
+.releaseDetails {
+  max-width: 41rem;
+}
+
+.release h3 {
+  max-width: 12ch;
+  margin-top: 0.6rem;
+  font-size: clamp(3.4rem, 6vw, 6.8rem);
+}
+
+.description {
+  margin: 1.3rem 0 0;
+  color: var(--color-paper-muted);
+  font-family: var(--font-serif), Georgia, serif;
+  font-size: clamp(1.3rem, 2vw, 1.7rem);
+  font-style: italic;
+  line-height: 1.25;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.9rem 1.25rem;
+  margin-top: 1.8rem;
+}
+
+.listenButton,
+.spotifyLink {
+  display: inline-flex;
+  min-height: 3.35rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  font-family: var(--font-display), sans-serif;
+  font-size: 1rem;
+  letter-spacing: 0.13em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.listenButton {
+  border: 1px solid var(--color-gold);
+  padding: 0.9rem 1.25rem;
+  color: var(--color-ink);
+  background: var(--color-gold);
+  transition:
+    color 160ms ease,
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.listenButton:hover:not(:disabled),
+.listenButton:focus-visible:not(:disabled) {
+  color: var(--color-ink);
+  background: var(--color-paper);
+  transform: translateY(-2px);
+}
+
+.listenButton:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+.spotifyLink {
+  border-bottom: 1px solid var(--color-gold);
+  padding: 0.3rem 0;
+  color: var(--color-paper);
+  transition:
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.spotifyLink:hover,
+.spotifyLink:focus-visible {
+  border-color: var(--color-paper);
+  color: var(--color-gold);
+}
+
+.spotifyLink img {
+  object-fit: contain;
+}
+
+.player {
+  width: min(100%, 34rem);
+  margin-top: 1.75rem;
+}
+
+.player iframe {
+  display: block;
+  border: 0;
+  border-radius: 0.75rem;
+}
+
+@media (max-width: 899px) {
+  .release {
+    grid-template-columns: minmax(0, 22rem) minmax(0, 1fr);
+    gap: clamp(1.5rem, 4vw, 3rem);
+  }
+}
+
+@media (max-width: 640px) {
+  .music {
+    padding-block: 4.5rem;
+  }
+
+  .heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .release {
+    grid-template-columns: 1fr;
+  }
+
+  .artworkLink {
+    width: min(100%, 26rem);
+  }
+
+  .release h3 {
+    font-size: clamp(3.4rem, 16vw, 5rem);
+  }
+}

--- a/src/app/home/MusicSection.tsx
+++ b/src/app/home/MusicSection.tsx
@@ -29,7 +29,7 @@ export function MusicSection({ releases }: { releases: MusicRelease[] }) {
               src={release.artwork}
               alt={`Cover art for ${release.title}`}
               fill
-              sizes="(max-width: 640px) calc(100vw - 2rem), (max-width: 899px) 22rem, 26rem"
+              sizes="(max-width: 640px) 5.5rem, 22rem"
               className={styles.artwork}
             />
           </div>
@@ -39,7 +39,6 @@ export function MusicSection({ releases }: { releases: MusicRelease[] }) {
 
             {release.spotifyUrl || release.appleMusicUrl ? (
               <div className={styles.listenOn}>
-                <p>Listen on</p>
                 <div className={styles.platformLinks}>
                   {release.spotifyUrl ? (
                     <a

--- a/src/app/home/MusicSection.tsx
+++ b/src/app/home/MusicSection.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import Image from "next/image";
+import { Play } from "lucide-react";
+import { useState } from "react";
+import styles from "./MusicSection.module.css";
+
+type MusicRelease = {
+  slug: string;
+  title: string;
+  artwork: string;
+  status: string;
+  description?: string;
+  spotifyUrl?: string;
+  featured?: boolean;
+};
+
+type SpotifyOEmbed = {
+  iframe_url?: string;
+};
+
+function embedFallbackUrl(spotifyUrl: string) {
+  const trackId = new URL(spotifyUrl).pathname.split("/").pop();
+  return `https://open.spotify.com/embed/track/${trackId}`;
+}
+
+export function MusicSection({ releases }: { releases: MusicRelease[] }) {
+  const release = releases.find((item) => item.featured && item.status === "released");
+  const [embedUrl, setEmbedUrl] = useState<string | null>(null);
+  const [isLoadingEmbed, setIsLoadingEmbed] = useState(false);
+
+  if (!release || !release.spotifyUrl) {
+    return null;
+  }
+
+  const spotifyUrl = release.spotifyUrl;
+  const playerId = `spotify-player-${release.slug}`;
+
+  async function revealPlayer() {
+    if (embedUrl || isLoadingEmbed) return;
+
+    setIsLoadingEmbed(true);
+
+    try {
+      const response = await fetch(
+        `https://open.spotify.com/oembed?url=${encodeURIComponent(spotifyUrl)}`,
+      );
+
+      if (!response.ok) {
+        throw new Error("Spotify oEmbed request failed.");
+      }
+
+      const embed = (await response.json()) as SpotifyOEmbed;
+      setEmbedUrl(embed.iframe_url ?? embedFallbackUrl(spotifyUrl));
+    } catch {
+      setEmbedUrl(embedFallbackUrl(spotifyUrl));
+    } finally {
+      setIsLoadingEmbed(false);
+    }
+  }
+
+  return (
+    <section id="music" className={styles.music} aria-labelledby="music-title">
+      <div className={styles.shell}>
+        <div className={styles.heading}>
+          <p className={styles.eyebrow}>Music</p>
+          <h2 id="music-title">New release</h2>
+        </div>
+
+        <article className={styles.release}>
+          <a
+            className={styles.artworkLink}
+            href={release.spotifyUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Open ${release.title} in Spotify`}
+          >
+            <Image
+              src={release.artwork}
+              alt={`Cover art for ${release.title}`}
+              fill
+              sizes="(max-width: 640px) calc(100vw - 2rem), (max-width: 899px) 22rem, 26rem"
+              className={styles.artwork}
+            />
+          </a>
+
+          <div className={styles.releaseDetails}>
+            <p className={styles.releaseType}>Single</p>
+            <h3>{release.title}</h3>
+            {release.description ? <p className={styles.description}>{release.description}</p> : null}
+
+            <div className={styles.actions}>
+              <button
+                type="button"
+                className={styles.listenButton}
+                aria-controls={playerId}
+                aria-expanded={Boolean(embedUrl)}
+                disabled={isLoadingEmbed}
+                onClick={revealPlayer}
+              >
+                <Play size={18} fill="currentColor" aria-hidden="true" />
+                {isLoadingEmbed ? "Loading player" : "Listen now"}
+              </button>
+              <a
+                className={styles.spotifyLink}
+                href={release.spotifyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Image src="/spotify.svg" alt="" width={20} height={20} />
+                Open in Spotify
+              </a>
+            </div>
+
+            {embedUrl ? (
+              <div id={playerId} className={styles.player}>
+                <iframe
+                  src={embedUrl}
+                  title={`Spotify: ${release.title}`}
+                  width="100%"
+                  height="152"
+                  allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                  loading="lazy"
+                />
+              </div>
+            ) : null}
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/src/app/home/MusicSection.tsx
+++ b/src/app/home/MusicSection.tsx
@@ -1,8 +1,4 @@
-"use client";
-
 import Image from "next/image";
-import { Play } from "lucide-react";
-import { useState } from "react";
 import styles from "./MusicSection.module.css";
 
 type MusicRelease = {
@@ -10,71 +6,25 @@ type MusicRelease = {
   title: string;
   artwork: string;
   status: string;
-  description?: string;
   spotifyUrl?: string;
+  appleMusicUrl?: string;
   featured?: boolean;
 };
 
-type SpotifyOEmbed = {
-  iframe_url?: string;
-};
-
-function embedFallbackUrl(spotifyUrl: string) {
-  const trackId = new URL(spotifyUrl).pathname.split("/").pop();
-  return `https://open.spotify.com/embed/track/${trackId}`;
-}
-
 export function MusicSection({ releases }: { releases: MusicRelease[] }) {
   const release = releases.find((item) => item.featured && item.status === "released");
-  const [embedUrl, setEmbedUrl] = useState<string | null>(null);
-  const [isLoadingEmbed, setIsLoadingEmbed] = useState(false);
 
-  if (!release || !release.spotifyUrl) {
+  if (!release) {
     return null;
-  }
-
-  const spotifyUrl = release.spotifyUrl;
-  const playerId = `spotify-player-${release.slug}`;
-
-  async function revealPlayer() {
-    if (embedUrl || isLoadingEmbed) return;
-
-    setIsLoadingEmbed(true);
-
-    try {
-      const response = await fetch(
-        `https://open.spotify.com/oembed?url=${encodeURIComponent(spotifyUrl)}`,
-      );
-
-      if (!response.ok) {
-        throw new Error("Spotify oEmbed request failed.");
-      }
-
-      const embed = (await response.json()) as SpotifyOEmbed;
-      setEmbedUrl(embed.iframe_url ?? embedFallbackUrl(spotifyUrl));
-    } catch {
-      setEmbedUrl(embedFallbackUrl(spotifyUrl));
-    } finally {
-      setIsLoadingEmbed(false);
-    }
   }
 
   return (
     <section id="music" className={styles.music} aria-labelledby="music-title">
       <div className={styles.shell}>
-        <div className={styles.heading}>
-          <p className={styles.eyebrow}>Music</p>
-          <h2 id="music-title">New release</h2>
-        </div>
+        <h2 id="music-title" className={styles.title}>Music</h2>
 
         <article className={styles.release}>
-          <a
-            className={styles.artworkLink}
-            href={release.spotifyUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={`Open ${release.title} in Spotify`}
-          >
+          <div className={styles.artworkFrame}>
             <Image
               src={release.artwork}
               alt={`Cover art for ${release.title}`}
@@ -82,46 +32,40 @@ export function MusicSection({ releases }: { releases: MusicRelease[] }) {
               sizes="(max-width: 640px) calc(100vw - 2rem), (max-width: 899px) 22rem, 26rem"
               className={styles.artwork}
             />
-          </a>
+          </div>
 
           <div className={styles.releaseDetails}>
-            <p className={styles.releaseType}>Single</p>
             <h3>{release.title}</h3>
-            {release.description ? <p className={styles.description}>{release.description}</p> : null}
 
-            <div className={styles.actions}>
-              <button
-                type="button"
-                className={styles.listenButton}
-                aria-controls={playerId}
-                aria-expanded={Boolean(embedUrl)}
-                disabled={isLoadingEmbed}
-                onClick={revealPlayer}
-              >
-                <Play size={18} fill="currentColor" aria-hidden="true" />
-                {isLoadingEmbed ? "Loading player" : "Listen now"}
-              </button>
-              <a
-                className={styles.spotifyLink}
-                href={release.spotifyUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Image src="/spotify.svg" alt="" width={20} height={20} />
-                Open in Spotify
-              </a>
-            </div>
-
-            {embedUrl ? (
-              <div id={playerId} className={styles.player}>
-                <iframe
-                  src={embedUrl}
-                  title={`Spotify: ${release.title}`}
-                  width="100%"
-                  height="152"
-                  allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                  loading="lazy"
-                />
+            {release.spotifyUrl || release.appleMusicUrl ? (
+              <div className={styles.listenOn}>
+                <p>Listen on</p>
+                <div className={styles.platformLinks}>
+                  {release.spotifyUrl ? (
+                    <a
+                      className={styles.platformLink}
+                      href={release.spotifyUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Listen to ${release.title} on Spotify`}
+                    >
+                      <Image src="/spotify.svg" alt="" width={20} height={20} />
+                      Spotify
+                    </a>
+                  ) : null}
+                  {release.appleMusicUrl ? (
+                    <a
+                      className={styles.platformLink}
+                      href={release.appleMusicUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Listen to ${release.title} on Apple Music`}
+                    >
+                      <Image src="/apple_music.svg" alt="" width={20} height={20} />
+                      Apple Music
+                    </a>
+                  ) : null}
+                </div>
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## What changed

- Added an embedded Spotify preview for the featured music release.
- Added platform-neutral Spotify and Apple Music release links.
- Refined the featured release card into a more compact presentation.

## Why

Gives visitors a clearer path to listen to Gary’s featured recording directly from the homepage.

## Validation

- `pnpm lint`
- `pnpm build`