### PR TITLE
Build routed Living Poster experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Gary Dacanay
 
-Single-page website for jazz vocalist and guitarist Gary Dacanay. The July 2026
-design presents Gary as a live artist for hire through a responsive,
-poster-inspired experience.
+Website for jazz vocalist and guitarist Gary Dacanay. The Living Poster design
+presents Gary as a live artist for hire through a responsive, single-screen
+shell with route-backed music, video, and photo experiences.
 
 ## Local development
 
@@ -17,12 +17,15 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Content
 
-Public copy, performance videos, booking-email content, and external social
-links live in `src/app/data.json`. Spotify and Apple Music URLs are retained
-there as optional content, but are intentionally not rendered until Gary
-approves their inclusion. The production hero and social-sharing artwork live
-in `public/images`; the two source candidates remain in
+Public copy, performance videos, booking-email content, releases, and external
+platform links live in `src/app/data.json`. The production hero and
+social-sharing artwork live in `public/images`; source candidates remain in
 `public/images/artwork-candidates` for future reference.
+
+The persistent shell is shared by `/`, `/music`, `/videos`, and `/photos`.
+The poster background is only mounted on `/`; media routes replace the center
+canvas while preserving the navigation, booking, newsletter, and platform
+controls.
 
 See [Music releases](docs/music-releases.md) for the planned staged rollout of
 release cards, Spotify embeds, and an eventual discography playlist.

--- a/src/app/data.json
+++ b/src/app/data.json
@@ -7,10 +7,10 @@
     "supportingCopy": "Timeless jazz for concerts, weddings, dinners, and private events."
   },
   "navigation": [
-    { "label": "Music", "href": "#music" },
-    { "label": "Videos", "href": "#videos" },
-    { "label": "Photos", "href": "#photographs" },
-    { "label": "Events", "href": "#events" }
+    { "label": "Home", "href": "/" },
+    { "label": "Music", "href": "/music" },
+    { "label": "Videos", "href": "/videos" },
+    { "label": "Photos", "href": "/photos" }
   ],
   "booking": {
     "subject": "Booking inquiry for Gary Dacanay",

--- a/src/app/home/NewsletterForm.module.css
+++ b/src/app/home/NewsletterForm.module.css
@@ -1,0 +1,90 @@
+.newsletter h2 {
+  max-width: 9ch;
+  margin: 0;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(2.8rem, 6vw, 4.8rem);
+  font-weight: 400;
+  line-height: 0.82;
+  text-transform: uppercase;
+}
+
+.newsletter > p {
+  max-width: 32rem;
+  margin: 1rem 0 0;
+  color: var(--color-paper-muted);
+  line-height: 1.55;
+}
+
+.newsletterForm {
+  max-width: 34rem;
+  margin-top: 1.25rem;
+}
+
+.newsletterForm label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--color-paper-muted);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.newsletterForm > div {
+  display: flex;
+}
+
+.newsletterForm input {
+  min-width: 0;
+  min-height: 3.1rem;
+  flex: 1;
+  border: 1px solid var(--color-rule);
+  border-right: 0;
+  border-radius: 0;
+  padding: 0.8rem;
+  color: var(--color-paper);
+  background: rgb(255 255 255 / 0.035);
+}
+
+.newsletterForm button {
+  min-height: 3.1rem;
+  border: 1px solid var(--color-gold);
+  padding: 0.8rem 1.1rem;
+  color: var(--color-ink);
+  background: var(--color-gold);
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.newsletterForm input:disabled,
+.newsletterForm button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.formSuccess,
+.formError {
+  margin-top: 0.85rem !important;
+  font-size: 0.78rem;
+}
+
+.formSuccess {
+  color: var(--color-gold) !important;
+}
+
+.formError {
+  color: #ef8b72 !important;
+}
+
+@media (max-width: 520px) {
+  .newsletterForm > div {
+    display: grid;
+  }
+
+  .newsletterForm input {
+    border-right: 1px solid var(--color-rule);
+    border-bottom: 0;
+  }
+}

--- a/src/app/home/NewsletterForm.tsx
+++ b/src/app/home/NewsletterForm.tsx
@@ -3,14 +3,14 @@
 import type { FormEvent } from "react";
 import { useState } from "react";
 import { subscribe } from "../actions";
-import styles from "./HomePage.module.css";
+import styles from "./NewsletterForm.module.css";
 
 type FormState = {
   kind: "idle" | "success" | "error";
   message: string;
 };
 
-export function NewsletterForm() {
+export function NewsletterForm({ titleId }: { titleId?: string }) {
   const [submitting, setSubmitting] = useState(false);
   const [state, setState] = useState<FormState>({ kind: "idle", message: "" });
 
@@ -40,7 +40,7 @@ export function NewsletterForm() {
 
   return (
     <div className={styles.newsletter}>
-      <h2>Stay in the Loop</h2>
+      <h2 id={titleId}>Stay in the Loop</h2>
       <p>Occasional messages about upcoming performances, recordings, and new music.</p>
       <form onSubmit={handleSubmit} className={styles.newsletterForm}>
         <label htmlFor="newsletter-email">Email address</label>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Bebas_Neue, Instrument_Serif, Inter } from "next/font/google";
 import "./styles.css";
 import data from "./data.json";
 import { siteUrl } from "./content";
+import { LivingPosterShell } from "./living-poster/LivingPosterShell";
 
 const display = Bebas_Neue({
   subsets: ["latin"],
@@ -55,9 +56,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" data-scroll-behavior="smooth">
       <body className={`${display.variable} ${serif.variable} ${sans.variable}`}>
-        {children}
+        <LivingPosterShell>{children}</LivingPosterShell>
       </body>
     </html>
   );

--- a/src/app/living-poster/LivingPosterShell.module.css
+++ b/src/app/living-poster/LivingPosterShell.module.css
@@ -43,8 +43,8 @@
 
 .posterBackdrop::before {
   background:
-    linear-gradient(90deg, #090807 0 24%, transparent 50% 76%, #090807 100%),
-    linear-gradient(0deg, #090807 0, transparent 22% 78%, rgb(9 8 7 / 0.72) 100%);
+    linear-gradient(90deg, #090807 0 24%, rgb(9 8 7 / 0.92) 34%, rgb(9 8 7 / 0.28) 52%, transparent 66%),
+    linear-gradient(0deg, rgb(9 8 7 / 0.72) 0, transparent 18% 86%, rgb(9 8 7 / 0.42) 100%);
 }
 
 .posterBackdrop::after {
@@ -52,8 +52,8 @@
 }
 
 .posterImage {
-  object-fit: cover;
-  object-position: 66% 24%;
+  object-fit: contain;
+  object-position: right center;
   filter: saturate(0.92) contrast(1.03);
 }
 
@@ -205,18 +205,18 @@
   height: 2rem;
   flex: 0 0 auto;
   place-items: center;
-  border: 1px solid var(--color-rule);
+  border: 0;
   border-radius: 50%;
-  background: rgb(255 255 255 / 0.025);
-  transition: border-color 160ms ease, background-color 160ms ease;
+  background: transparent;
+  transition: background-color 160ms ease, transform 160ms ease;
 }
 
 .desktopPlatforms a:hover,
 .desktopPlatforms a:focus-visible,
 .mobilePlatforms a:hover,
 .mobilePlatforms a:focus-visible {
-  border-color: var(--color-gold);
   background: rgb(214 166 62 / 0.12);
+  transform: translateY(-1px);
 }
 
 .desktopPlatforms img,
@@ -225,6 +225,7 @@
 }
 
 .mobilePlatforms,
+.mobileUtilities,
 .mobileTabs {
   display: none;
 }
@@ -340,10 +341,41 @@
   max-width: 44rem;
 }
 
+@media (min-width: 761px) and (max-width: 1120px) {
+  .posterBackdrop::before {
+    background:
+      linear-gradient(0deg, #090807 0 4%, rgb(9 8 7 / 0.9) 16%, transparent 48%),
+      linear-gradient(90deg, #090807 0 7%, rgb(9 8 7 / 0.82) 18%, transparent 45%);
+  }
+
+  .posterImage {
+    object-position: right top;
+  }
+
+  .header {
+    padding-inline: 1.25rem;
+  }
+
+  .desktopNav {
+    gap: 1.2rem;
+  }
+
+  .desktopUtilities {
+    grid-template-columns: repeat(2, minmax(12rem, 1fr)) minmax(20rem, 1.35fr);
+  }
+
+  .desktopUtilities > button {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.25rem;
+  }
+}
+
 @media (max-width: 760px) {
   .shell {
     min-height: 34rem;
-    grid-template-rows: calc(4rem + env(safe-area-inset-top)) minmax(0, 1fr) 3rem calc(4.6rem + env(safe-area-inset-bottom));
+    grid-template-rows: calc(4rem + env(safe-area-inset-top)) minmax(0, 1fr) 3rem 3.6rem calc(4.6rem + env(safe-area-inset-bottom));
   }
 
   .header {
@@ -380,6 +412,7 @@
   }
 
   .posterImage {
+    object-fit: cover;
     object-position: 51% 30%;
   }
 
@@ -410,14 +443,64 @@
   .mobilePlatforms a {
     width: 2.7rem;
     height: 2.7rem;
+  }
+
+  .mobileUtilities {
+    position: relative;
+    z-index: 20;
+    display: grid;
+    grid-row: 4;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    border-top: 1px solid var(--color-rule);
+    background: rgb(9 8 7 / 0.97);
+  }
+
+  .mobileUtilities button {
+    display: flex;
+    min-width: 0;
+    align-items: flex-start;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.15rem;
     border: 0;
+    border-right: 1px solid var(--color-rule);
+    padding: 0.45rem 1rem;
+    color: var(--color-paper);
+    background: transparent;
+    text-align: left;
+  }
+
+  .mobileUtilities button:last-child {
+    border-right: 0;
+  }
+
+  .mobileUtilities button:hover,
+  .mobileUtilities button:focus-visible {
+    background: rgb(214 166 62 / 0.1);
+  }
+
+  .mobileUtilities span {
+    color: var(--color-paper-muted);
+    font-size: 0.5rem;
+    font-weight: 600;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+  }
+
+  .mobileUtilities strong {
+    color: var(--color-gold);
+    font-family: var(--font-serif), Georgia, serif;
+    font-size: clamp(0.82rem, 3.8vw, 1rem);
+    font-style: italic;
+    font-weight: 400;
+    line-height: 1;
   }
 
   .mobileTabs {
     position: relative;
     z-index: 20;
     display: grid;
-    grid-row: 4;
+    grid-row: 5;
     grid-template-columns: repeat(4, 1fr);
     padding-bottom: env(safe-area-inset-bottom);
     border-top: 1px solid var(--color-rule);

--- a/src/app/living-poster/LivingPosterShell.module.css
+++ b/src/app/living-poster/LivingPosterShell.module.css
@@ -1,0 +1,475 @@
+.shell {
+  position: relative;
+  display: grid;
+  width: 100%;
+  height: 100dvh;
+  min-height: 36rem;
+  grid-template-rows: 4.25rem minmax(0, 1fr) 4.65rem;
+  overflow: hidden;
+  color: var(--color-paper);
+  background: #0b0908;
+  isolation: isolate;
+}
+.shell::after {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  content: "";
+  pointer-events: none;
+  opacity: 0.14;
+  background-image:
+    repeating-radial-gradient(circle at 18% 22%, transparent 0 2px, rgb(244 228 184 / 0.08) 3px 4px),
+    repeating-linear-gradient(92deg, transparent 0 7px, rgb(0 0 0 / 0.18) 8px 9px);
+  background-size: 17px 19px, 41px 100%;
+  mix-blend-mode: soft-light;
+}
+
+.posterBackdrop {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  overflow: hidden;
+  background: #090807;
+}
+
+.posterBackdrop::before,
+.posterBackdrop::after {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  content: "";
+  pointer-events: none;
+}
+
+.posterBackdrop::before {
+  background:
+    linear-gradient(90deg, #090807 0 24%, transparent 50% 76%, #090807 100%),
+    linear-gradient(0deg, #090807 0, transparent 22% 78%, rgb(9 8 7 / 0.72) 100%);
+}
+
+.posterBackdrop::after {
+  background: linear-gradient(135deg, rgb(214 166 62 / 0.05), transparent 42%);
+}
+
+.posterImage {
+  object-fit: cover;
+  object-position: 66% 24%;
+  filter: saturate(0.92) contrast(1.03);
+}
+
+.header {
+  position: relative;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  border-bottom: 1px solid var(--color-rule);
+  padding: 0 clamp(1rem, 2.7vw, 2.5rem);
+  background: rgb(10 9 8 / 0.72);
+  backdrop-filter: blur(8px);
+}
+
+.brand {
+  width: fit-content;
+  color: var(--color-gold);
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(1.2rem, 2vw, 1.55rem);
+  letter-spacing: 0.1em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.desktopNav {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 2.4vw, 2.2rem);
+}
+
+.desktopNav a {
+  border-bottom: 1px solid transparent;
+  padding: 0.3rem 0;
+  color: var(--color-paper-muted);
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  transition: color 160ms ease, border-color 160ms ease;
+}
+
+.desktopNav a:hover,
+.desktopNav a:focus-visible,
+.desktopNav a[aria-current="page"] {
+  border-color: var(--color-gold);
+  color: var(--color-gold);
+}
+
+.availabilityButton {
+  display: inline-flex;
+  min-height: 2.4rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  justify-self: end;
+  border: 1px solid var(--color-gold);
+  padding: 0.55rem 0.8rem;
+  color: var(--color-ink);
+  background: var(--color-gold);
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.74rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.canvas {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.shell[data-home="false"] .canvas {
+  background:
+    linear-gradient(135deg, rgb(214 166 62 / 0.035), transparent 42%),
+    #0d0b09;
+}
+
+.desktopUtilities {
+  position: relative;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: minmax(13rem, 0.85fr) minmax(13rem, 0.85fr) minmax(22rem, 1.45fr);
+  border-top: 1px solid var(--color-rule);
+  background: rgb(10 9 8 / 0.9);
+  backdrop-filter: blur(12px);
+}
+
+.desktopUtilities > button {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 0;
+  border-right: 1px solid var(--color-rule);
+  padding: 0.8rem 1.2rem;
+  color: var(--color-paper);
+  background: transparent;
+  text-align: left;
+}
+
+.desktopUtilities > button:hover,
+.desktopUtilities > button:focus-visible {
+  background: rgb(214 166 62 / 0.08);
+}
+
+.desktopUtilities > button span,
+.desktopPlatforms > span {
+  color: var(--color-paper-muted);
+  font-size: 0.56rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.desktopUtilities > button strong {
+  color: var(--color-gold);
+  font-family: var(--font-serif), Georgia, serif;
+  font-size: 0.96rem;
+  font-style: italic;
+  font-weight: 400;
+}
+
+.desktopPlatforms,
+.mobilePlatforms {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.65rem 1.1rem;
+}
+
+.desktopPlatforms > div,
+.mobilePlatforms > div {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: clamp(0.45rem, 1vw, 0.8rem);
+}
+
+.desktopPlatforms a,
+.mobilePlatforms a {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--color-rule);
+  border-radius: 50%;
+  background: rgb(255 255 255 / 0.025);
+  transition: border-color 160ms ease, background-color 160ms ease;
+}
+
+.desktopPlatforms a:hover,
+.desktopPlatforms a:focus-visible,
+.mobilePlatforms a:hover,
+.mobilePlatforms a:focus-visible {
+  border-color: var(--color-gold);
+  background: rgb(214 166 62 / 0.12);
+}
+
+.desktopPlatforms img,
+.mobilePlatforms img {
+  object-fit: contain;
+}
+
+.mobilePlatforms,
+.mobileTabs {
+  display: none;
+}
+
+.utilityDialog {
+  width: 100%;
+  max-width: none;
+  height: auto;
+  max-height: calc(100dvh - 4.25rem);
+  margin: auto 0 0;
+  border: 0;
+  border-top: 1px solid var(--color-gold);
+  padding: 0;
+  color: var(--color-paper);
+  background: #100e0c;
+  box-shadow: 0 -24px 70px rgb(0 0 0 / 0.7);
+}
+
+.utilityDialog::backdrop {
+  background: rgb(0 0 0 / 0.68);
+  backdrop-filter: blur(3px);
+}
+
+.utilityPanel {
+  position: relative;
+  max-height: calc(100dvh - 4.25rem);
+  overflow-y: auto;
+  padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1.25rem, 5vw, 5rem);
+}
+
+.dialogClose {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  place-items: center;
+  border: 1px solid var(--color-rule);
+  padding: 0;
+  color: var(--color-paper);
+  background: transparent;
+}
+
+.bookingPanel h2 {
+  max-width: 11ch;
+  margin: 0;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(3rem, 6vw, 5.4rem);
+  font-weight: 400;
+  line-height: 0.82;
+  text-transform: uppercase;
+}
+
+.kicker {
+  margin: 0 0 0.8rem;
+  color: var(--color-gold);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+.dialogCopy {
+  max-width: 36rem;
+  margin: 1rem 0 0;
+  color: var(--color-paper-muted);
+  line-height: 1.55;
+}
+
+.eventTypes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1.2rem;
+  margin-top: 1.2rem;
+  color: var(--color-paper-muted);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.bookingActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.primaryAction {
+  display: inline-flex;
+  min-height: 3rem;
+  align-items: center;
+  border: 1px solid var(--color-gold);
+  padding: 0.8rem 1.1rem;
+  color: var(--color-ink);
+  background: var(--color-gold);
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.emailLink {
+  border-bottom: 1px solid var(--color-rule);
+  padding-bottom: 0.25rem;
+  color: var(--color-gold);
+  font-size: 0.8rem;
+}
+
+.newsletterPanel {
+  max-width: 44rem;
+}
+
+@media (max-width: 760px) {
+  .shell {
+    min-height: 34rem;
+    grid-template-rows: calc(4rem + env(safe-area-inset-top)) minmax(0, 1fr) 3rem calc(4.6rem + env(safe-area-inset-bottom));
+  }
+
+  .header {
+    grid-template-columns: 1fr auto;
+    padding: env(safe-area-inset-top) 1rem 0;
+    background: rgb(9 8 7 / 0.72);
+  }
+
+  .brand {
+    font-size: 1.22rem;
+  }
+
+  .desktopNav,
+  .availabilityButton svg,
+  .desktopUtilities {
+    display: none;
+  }
+
+  .availabilityButton {
+    display: inline-flex;
+    min-height: 2.25rem;
+    padding: 0.5rem 0.65rem;
+    font-size: 0.68rem;
+  }
+
+  .posterBackdrop {
+    bottom: 0;
+  }
+
+  .posterBackdrop::before {
+    background:
+      linear-gradient(0deg, #090807 0 7%, transparent 36% 72%, rgb(9 8 7 / 0.72) 100%),
+      linear-gradient(90deg, rgb(9 8 7 / 0.34), transparent 48%, rgb(9 8 7 / 0.16));
+  }
+
+  .posterImage {
+    object-position: 51% 30%;
+  }
+
+  .mobilePlatforms {
+    position: relative;
+    z-index: 20;
+    display: flex;
+    grid-row: 3;
+    align-items: center;
+    justify-content: center;
+    border-top: 1px solid var(--color-rule);
+    padding: 0 0.75rem;
+    background: rgb(9 8 7 / 0.95);
+  }
+
+  .mobilePlatforms > span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+  }
+
+  .mobilePlatforms > div {
+    gap: clamp(1rem, 7vw, 1.9rem);
+  }
+
+  .mobilePlatforms a {
+    width: 2.7rem;
+    height: 2.7rem;
+    border: 0;
+  }
+
+  .mobileTabs {
+    position: relative;
+    z-index: 20;
+    display: grid;
+    grid-row: 4;
+    grid-template-columns: repeat(4, 1fr);
+    padding-bottom: env(safe-area-inset-bottom);
+    border-top: 1px solid var(--color-rule);
+    background: rgb(9 8 7 / 0.96);
+    backdrop-filter: blur(12px);
+  }
+
+  .mobileTabs a {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.3rem;
+    border-right: 1px solid var(--color-rule);
+    color: var(--color-paper-muted);
+    font-family: var(--font-display), sans-serif;
+    font-size: 0.68rem;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .mobileTabs a:last-child {
+    border-right: 0;
+  }
+
+  .mobileTabs a[aria-current="page"] {
+    color: var(--color-gold);
+    background: rgb(214 166 62 / 0.08);
+  }
+
+  .canvas {
+    grid-row: 2;
+  }
+
+  .utilityDialog {
+    max-height: calc(100dvh - 2rem);
+  }
+
+  .utilityPanel {
+    max-height: calc(100dvh - 2rem);
+    padding: 2.8rem 1.2rem 1.5rem;
+  }
+
+  .bookingPanel h2 {
+    font-size: clamp(2.8rem, 13vw, 4rem);
+  }
+}
+
+@media (max-height: 620px) and (min-width: 761px) {
+  .shell {
+    min-height: 30rem;
+    grid-template-rows: 3.75rem minmax(0, 1fr) 4rem;
+  }
+}

--- a/src/app/living-poster/LivingPosterShell.module.css
+++ b/src/app/living-poster/LivingPosterShell.module.css
@@ -52,9 +52,24 @@
 }
 
 .posterImage {
-  object-fit: contain;
-  object-position: right center;
+  object-fit: cover;
+  object-position: 50% 18%;
   filter: saturate(0.92) contrast(1.03);
+}
+
+@media (min-width: 1121px) {
+  .posterBackdrop::before {
+    background: linear-gradient(0deg, rgb(9 8 7 / 0.72) 0, transparent 18% 86%, rgb(9 8 7 / 0.42) 100%);
+  }
+
+  .posterImage {
+    inset: 0 0 0 auto !important;
+    width: 60vw !important;
+    height: 100% !important;
+    object-position: 50% 18%;
+    -webkit-mask-image: linear-gradient(90deg, transparent 0, rgb(0 0 0 / 0.2) 7%, #000 22%);
+    mask-image: linear-gradient(90deg, transparent 0, rgb(0 0 0 / 0.2) 7%, #000 22%);
+  }
 }
 
 .header {
@@ -349,7 +364,7 @@
   }
 
   .posterImage {
-    object-position: right top;
+    object-position: 50% 18%;
   }
 
   .header {

--- a/src/app/living-poster/LivingPosterShell.tsx
+++ b/src/app/living-poster/LivingPosterShell.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { CalendarDays, Home, Images, Music2, Video, X } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import data from "../data.json";
+import { bookingHref } from "../content";
+import { NewsletterForm } from "../home/NewsletterForm";
+import styles from "./LivingPosterShell.module.css";
+
+const routes = [
+  { label: "Home", href: "/", icon: Home },
+  { label: "Music", href: "/music", icon: Music2 },
+  { label: "Videos", href: "/videos", icon: Video },
+  { label: "Photos", href: "/photos", icon: Images },
+];
+
+const platforms = [
+  { label: "YouTube", href: data.social.youtube, icon: "/youtube.svg" },
+  { label: "Instagram", href: data.social.instagram, icon: "/instagram.svg" },
+  { label: "Facebook", href: data.social.facebook, icon: "/facebook.svg" },
+  { label: "Spotify", href: data.music.spotify, icon: "/spotify.svg" },
+  { label: "Apple Music", href: data.music.apple_music, icon: "/apple_music.svg" },
+];
+
+type Drawer = "booking" | "newsletter" | null;
+
+export function LivingPosterShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const [drawer, setDrawer] = useState<Drawer>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  const isHome = pathname === "/";
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (drawer) {
+      if (!dialog.open) dialog.showModal();
+      window.requestAnimationFrame(() => closeRef.current?.focus());
+    } else if (dialog.open) {
+      dialog.close();
+    }
+  }, [drawer]);
+
+  return (
+    <div className={styles.shell} data-home={isHome ? "true" : "false"}>
+      {isHome ? (
+        <div className={styles.posterBackdrop} aria-hidden="true">
+          <Image
+            src="/images/hero-gary.webp"
+            alt=""
+            fill
+            priority
+            sizes="100vw"
+            className={styles.posterImage}
+          />
+        </div>
+      ) : null}
+
+      <header className={styles.header}>
+        <Link href="/" className={styles.brand} aria-label={`${data.name}, home`}>
+          {data.name}
+        </Link>
+
+        <nav className={styles.desktopNav} aria-label="Primary navigation">
+          {routes.map((route) => (
+            <Link
+              key={route.href}
+              href={route.href}
+              aria-current={pathname === route.href ? "page" : undefined}
+              onClick={() => setDrawer(null)}
+            >
+              {route.label}
+            </Link>
+          ))}
+        </nav>
+
+        <button
+          type="button"
+          className={styles.availabilityButton}
+          onClick={() => setDrawer("booking")}
+        >
+          <CalendarDays size={15} aria-hidden="true" />
+          <span>Availability</span>
+        </button>
+      </header>
+
+      <main className={styles.canvas}>{children}</main>
+
+      <footer className={styles.desktopUtilities}>
+        <button type="button" onClick={() => setDrawer("booking")}>
+          <span>Plan an event</span>
+          <strong>Check availability →</strong>
+        </button>
+        <button type="button" onClick={() => setDrawer("newsletter")}>
+          <span>Stay in tune</span>
+          <strong>Join the mailing list</strong>
+        </button>
+        <PlatformLinks className={styles.desktopPlatforms} />
+      </footer>
+
+      <PlatformLinks className={styles.mobilePlatforms} />
+
+      <nav className={styles.mobileTabs} aria-label="Primary navigation">
+        {routes.map((route) => {
+          const Icon = route.icon;
+          return (
+            <Link
+              key={route.href}
+              href={route.href}
+              aria-current={pathname === route.href ? "page" : undefined}
+              onClick={() => setDrawer(null)}
+            >
+              <Icon size={18} strokeWidth={1.7} aria-hidden="true" />
+              <span>{route.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+
+      <dialog
+        ref={dialogRef}
+        className={styles.utilityDialog}
+        aria-labelledby="utility-dialog-title"
+        onClose={() => setDrawer(null)}
+        onCancel={(event) => {
+          event.preventDefault();
+          setDrawer(null);
+        }}
+        onClick={(event) => {
+          if (event.target === event.currentTarget) setDrawer(null);
+        }}
+      >
+        <div className={styles.utilityPanel}>
+          <button
+            ref={closeRef}
+            type="button"
+            className={styles.dialogClose}
+            aria-label="Close panel"
+            onClick={() => setDrawer(null)}
+          >
+            <X size={20} aria-hidden="true" />
+          </button>
+
+          {drawer === "booking" ? (
+            <div className={styles.bookingPanel}>
+              <p className={styles.kicker}>Live music, considered for the room</p>
+              <h2 id="utility-dialog-title">Bring the songbook to your event</h2>
+              <p className={styles.dialogCopy}>
+                Share the date, location, occasion, and guest count. Gary will follow up
+                with availability.
+              </p>
+              <div className={styles.eventTypes} aria-label="Event types">
+                {data.services.map((service) => (
+                  <span key={service.name}>{service.name}</span>
+                ))}
+              </div>
+              <div className={styles.bookingActions}>
+                <a className={styles.primaryAction} href={bookingHref}>
+                  Start an inquiry
+                </a>
+                <a className={styles.emailLink} href={`mailto:${data.email}`}>
+                  {data.email}
+                </a>
+              </div>
+            </div>
+          ) : drawer === "newsletter" ? (
+            <div className={styles.newsletterPanel}>
+              <p className={styles.kicker}>New recordings &amp; performances</p>
+              <NewsletterForm titleId="utility-dialog-title" />
+            </div>
+          ) : null}
+        </div>
+      </dialog>
+    </div>
+  );
+}
+
+function PlatformLinks({ className }: { className: string }) {
+  return (
+    <div className={className}>
+      <span>Follow / listen</span>
+      <div>
+        {platforms.map((platform) => (
+          <a
+            key={platform.label}
+            href={platform.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={platform.label}
+          >
+            <Image src={platform.icon} alt="" width={18} height={18} />
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/living-poster/LivingPosterShell.tsx
+++ b/src/app/living-poster/LivingPosterShell.tsx
@@ -106,6 +106,17 @@ export function LivingPosterShell({ children }: { children: ReactNode }) {
 
       <PlatformLinks className={styles.mobilePlatforms} />
 
+      <div className={styles.mobileUtilities} aria-label="Quick actions">
+        <button type="button" onClick={() => setDrawer("booking")}>
+          <span>Plan an event</span>
+          <strong>Check availability</strong>
+        </button>
+        <button type="button" onClick={() => setDrawer("newsletter")}>
+          <span>Stay in tune</span>
+          <strong>Join the mailing list</strong>
+        </button>
+      </div>
+
       <nav className={styles.mobileTabs} aria-label="Primary navigation">
         {routes.map((route) => {
           const Icon = route.icon;

--- a/src/app/living-poster/MusicView.module.css
+++ b/src/app/living-poster/MusicView.module.css
@@ -1,0 +1,138 @@
+.view {
+  display: grid;
+  width: min(100%, 78rem);
+  height: 100%;
+  min-height: 0;
+  grid-template-columns: minmax(16rem, 0.86fr) minmax(20rem, 1.14fr);
+  align-items: center;
+  gap: clamp(2rem, 7vw, 6rem);
+  margin-inline: auto;
+  padding: clamp(1.25rem, 3vw, 2.75rem) clamp(1.25rem, 4vw, 4rem);
+}
+.artwork {
+  position: relative;
+  width: min(100%, 30rem);
+  aspect-ratio: 1;
+  justify-self: end;
+  overflow: hidden;
+  border: 1px solid rgb(244 228 184 / 0.24);
+  box-shadow: 0 2rem 5rem rgb(0 0 0 / 0.32);
+}
+
+.artwork img {
+  object-fit: cover;
+}
+
+.details {
+  align-self: center;
+}
+
+.kicker {
+  margin: 0 0 0.75rem;
+  color: var(--color-gold);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.details h1 {
+  max-width: 9ch;
+  margin: 0;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(3.5rem, 7vw, 7rem);
+  font-weight: 400;
+  line-height: 0.8;
+  letter-spacing: -0.025em;
+  text-transform: uppercase;
+}
+
+.description {
+  max-width: 31rem;
+  margin: 1.25rem 0 0;
+  color: var(--color-paper-muted);
+  font-family: var(--font-serif), Georgia, serif;
+  font-size: clamp(1.05rem, 1.7vw, 1.35rem);
+  font-style: italic;
+  line-height: 1.35;
+}
+
+.listenLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.listenLinks a {
+  display: inline-flex;
+  min-height: 3rem;
+  align-items: center;
+  gap: 0.6rem;
+  border: 1px solid var(--color-rule);
+  padding: 0.65rem 0.85rem;
+  font-family: var(--font-display), sans-serif;
+  font-size: 0.76rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.listenLinks a:hover,
+.listenLinks a:focus-visible {
+  border-color: var(--color-gold);
+  color: var(--color-gold);
+}
+
+@media (max-width: 760px) {
+  .view {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr) auto;
+    gap: 1rem;
+    overflow-y: auto;
+    padding: 1rem;
+  }
+
+  .artwork {
+    width: min(100%, 52vh);
+    min-width: 0;
+    align-self: center;
+    justify-self: center;
+  }
+
+  .details {
+    width: 100%;
+  }
+
+  .details h1 {
+    max-width: none;
+    font-size: clamp(2.6rem, 12vw, 4rem);
+  }
+
+  .description {
+    display: none;
+  }
+
+  .listenLinks {
+    margin-top: 0.85rem;
+  }
+
+  .listenLinks a {
+    min-height: 2.6rem;
+    flex: 1;
+    justify-content: center;
+    padding: 0.5rem;
+    font-size: 0.66rem;
+  }
+}
+
+@media (max-height: 680px) and (max-width: 760px) {
+  .view {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .artwork {
+    width: min(63vw, 16rem);
+    flex: 0 0 auto;
+  }
+}

--- a/src/app/living-poster/MusicView.tsx
+++ b/src/app/living-poster/MusicView.tsx
@@ -1,0 +1,48 @@
+import Image from "next/image";
+import data from "../data.json";
+import styles from "./MusicView.module.css";
+
+export function MusicView() {
+  const release = data.music.releases.find(
+    (item) => item.featured && item.status === "released",
+  );
+
+  if (!release) return null;
+
+  return (
+    <section className={styles.view} aria-labelledby="music-title">
+      <div className={styles.artwork}>
+        <Image
+          src={release.artwork}
+          alt={`Cover art for ${release.title}`}
+          fill
+          priority
+          sizes="(max-width: 700px) 82vw, 40vw"
+        />
+      </div>
+
+      <div className={styles.details}>
+        <p className={styles.kicker}>Featured recording · Single</p>
+        <h1 id="music-title">{release.title}</h1>
+        <p className={styles.description}>
+          Gary’s intimate vocal-and-guitar interpretation of a timeless standard.
+          Choose a service to listen in full.
+        </p>
+        <div className={styles.listenLinks}>
+          {release.spotifyUrl ? (
+            <a href={release.spotifyUrl} target="_blank" rel="noopener noreferrer">
+              <Image src="/spotify.svg" alt="" width={22} height={22} />
+              <span>Listen on Spotify</span>
+            </a>
+          ) : null}
+          {release.appleMusicUrl ? (
+            <a href={release.appleMusicUrl} target="_blank" rel="noopener noreferrer">
+              <Image src="/apple_music.svg" alt="" width={22} height={22} />
+              <span>Listen on Apple Music</span>
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/living-poster/PhotosView.module.css
+++ b/src/app/living-poster/PhotosView.module.css
@@ -1,0 +1,309 @@
+.view {
+  display: grid;
+  width: min(100%, 92rem);
+  height: 100%;
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr) clamp(3.2rem, 8vh, 5rem);
+  gap: 0.7rem;
+  margin-inline: auto;
+  padding: clamp(0.85rem, 2vw, 1.5rem) clamp(1rem, 3vw, 2.8rem);
+}
+
+.header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.kicker {
+  margin: 0 0 0.35rem;
+  color: var(--color-gold);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.header h1 {
+  margin: 0;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(2.2rem, 4vw, 3.8rem);
+  font-weight: 400;
+  line-height: 0.8;
+  text-transform: uppercase;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.controls > span {
+  min-width: 4rem;
+  color: var(--color-paper-muted);
+  font-size: 0.6rem;
+  letter-spacing: 0.12em;
+  text-align: center;
+}
+
+.controls button,
+.lightboxToolbar button,
+.lightboxNavigation button {
+  display: grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  place-items: center;
+  border: 1px solid var(--color-rule);
+  padding: 0;
+  color: var(--color-paper);
+  background: #15110e;
+}
+
+.controls button:hover,
+.controls button:focus-visible,
+.lightboxToolbar button:hover:not(:disabled),
+.lightboxToolbar button:focus-visible,
+.lightboxNavigation button:hover,
+.lightboxNavigation button:focus-visible {
+  border-color: var(--color-gold);
+  color: var(--color-ink);
+  background: var(--color-gold);
+}
+
+.desktopStage {
+  position: relative;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid rgb(244 228 184 / 0.18);
+  padding: 0;
+  background: #080706;
+}
+
+.desktopStage::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  pointer-events: none;
+  background: linear-gradient(90deg, rgb(10 9 8 / 0.18), transparent 24% 76%, rgb(10 9 8 / 0.18));
+}
+
+.desktopStage img {
+  object-fit: cover;
+  transition: transform 350ms ease, filter 220ms ease;
+}
+
+.desktopStage:hover img,
+.desktopStage:focus-visible img {
+  filter: saturate(1.04);
+  transform: scale(1.012);
+}
+
+.thumbnails {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.thumbnails button {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid transparent;
+  padding: 0;
+  background: #080706;
+  opacity: 0.5;
+}
+
+.thumbnails button:hover,
+.thumbnails button:focus-visible,
+.thumbnails button[aria-current="true"] {
+  border-color: var(--color-gold);
+  opacity: 1;
+}
+
+.thumbnails img,
+.mobileSlide img {
+  object-fit: cover;
+}
+
+.mobileScroller,
+.mobileControls {
+  display: none;
+}
+
+.mobileSlide {
+  position: relative;
+}
+
+.lightbox {
+  width: 100vw;
+  max-width: none;
+  height: 100dvh;
+  max-height: none;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  color: var(--color-paper);
+  background: #080706;
+}
+
+.lightbox::backdrop {
+  background: #080706;
+}
+
+.lightboxFrame {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  grid-template-rows: calc(3.8rem + env(safe-area-inset-top)) minmax(0, 1fr) calc(3.5rem + env(safe-area-inset-bottom));
+}
+
+.lightboxToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-rule);
+  padding: env(safe-area-inset-top) 0.85rem 0;
+  background: #0d0b09;
+}
+
+.lightboxToolbar > span {
+  color: var(--color-paper-muted);
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+}
+
+.lightboxToolbar > div {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.lightboxToolbar button:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+.lightboxStage {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: #050504;
+  touch-action: none;
+}
+
+.lightboxImage {
+  position: absolute;
+  inset: 0;
+  transform-origin: center;
+  transition: transform 180ms ease;
+}
+
+.lightboxImage img {
+  object-fit: contain;
+  user-select: none;
+}
+
+.lightboxNavigation {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  border-top: 1px solid var(--color-rule);
+  padding-bottom: env(safe-area-inset-bottom);
+  background: #0d0b09;
+}
+
+.lightboxNavigation span {
+  color: var(--color-paper-muted);
+  font-size: 0.55rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 760px) {
+  .view {
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    gap: 0.6rem;
+    padding: 0.75rem 0 0;
+  }
+
+  .header {
+    padding-inline: 1rem;
+  }
+
+  .header .controls {
+    display: none;
+  }
+
+  .header h1 {
+    font-size: 2.15rem;
+  }
+
+  .desktopStage,
+  .thumbnails {
+    display: none;
+  }
+
+  .mobileScroller {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+    touch-action: pan-x pinch-zoom;
+  }
+
+  .mobileScroller::-webkit-scrollbar {
+    display: none;
+  }
+
+  .mobileSlide {
+    min-width: 100%;
+    flex: 0 0 100%;
+    border: 0;
+    padding: 0;
+    background: #080706;
+    scroll-snap-align: center;
+    scroll-snap-stop: always;
+  }
+
+  .mobileSlide::after {
+    position: absolute;
+    inset: auto 0 0;
+    height: 20%;
+    content: "";
+    background: linear-gradient(0deg, rgb(10 9 8 / 0.45), transparent);
+    pointer-events: none;
+  }
+
+  .mobileControls {
+    display: flex;
+    justify-content: center;
+    padding: 0 1rem 0.7rem;
+  }
+
+  .mobileControls .controls {
+    justify-content: center;
+  }
+
+  .lightboxNavigation span {
+    max-width: 9rem;
+    text-align: center;
+  }
+}
+
+@media (max-height: 650px) and (max-width: 760px) {
+  .header h1 {
+    font-size: 1.8rem;
+  }
+
+  .kicker {
+    display: none;
+  }
+}

--- a/src/app/living-poster/PhotosView.module.css
+++ b/src/app/living-poster/PhotosView.module.css
@@ -11,27 +11,17 @@
 
 .header {
   display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 1rem;
+  align-items: center;
+  justify-content: flex-end;
 }
 
-.kicker {
-  margin: 0 0 0.35rem;
-  color: var(--color-gold);
-  font-size: 0.62rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-}
-
-.header h1 {
-  margin: 0;
-  font-family: var(--font-display), sans-serif;
-  font-size: clamp(2.2rem, 4vw, 3.8rem);
-  font-weight: 400;
-  line-height: 0.8;
-  text-transform: uppercase;
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .controls {
@@ -74,23 +64,19 @@
 
 .desktopStage {
   position: relative;
+  width: min(100%, calc(100dvh - 18rem));
   min-height: 0;
+  aspect-ratio: 1;
+  align-self: center;
+  justify-self: center;
   overflow: hidden;
   border: 1px solid rgb(244 228 184 / 0.18);
   padding: 0;
   background: #080706;
 }
 
-.desktopStage::after {
-  position: absolute;
-  inset: 0;
-  content: "";
-  pointer-events: none;
-  background: linear-gradient(90deg, rgb(10 9 8 / 0.18), transparent 24% 76%, rgb(10 9 8 / 0.18));
-}
-
 .desktopStage img {
-  object-fit: cover;
+  object-fit: contain;
   transition: transform 350ms ease, filter 220ms ease;
 }
 
@@ -103,13 +89,19 @@
 .thumbnails {
   display: grid;
   min-width: 0;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
+  grid-auto-columns: clamp(3.2rem, 8vh, 5rem);
+  grid-auto-flow: column;
+  justify-content: center;
   gap: 0.4rem;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-rule) transparent;
 }
 
 .thumbnails button {
   position: relative;
   min-width: 0;
+  aspect-ratio: 1;
   overflow: hidden;
   border: 1px solid transparent;
   padding: 0;
@@ -126,7 +118,7 @@
 
 .thumbnails img,
 .mobileSlide img {
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .mobileScroller,
@@ -224,23 +216,38 @@
   text-transform: uppercase;
 }
 
+@media (min-width: 761px) and (max-width: 1120px) {
+  .view {
+    height: 100%;
+    grid-template-rows: auto auto auto;
+    padding: 1rem clamp(1.25rem, 4vw, 2.5rem) 2rem;
+    overflow-y: auto;
+    overscroll-behavior-y: contain;
+  }
+
+  .desktopStage {
+    width: min(100%, 46rem);
+  }
+
+  .thumbnails {
+    grid-auto-columns: auto;
+    grid-auto-flow: row;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    justify-content: stretch;
+    gap: 0.65rem;
+    overflow: visible;
+  }
+}
+
 @media (max-width: 760px) {
   .view {
-    grid-template-rows: auto minmax(0, 1fr) auto;
+    grid-template-rows: minmax(0, 1fr) auto;
     gap: 0.6rem;
-    padding: 0.75rem 0 0;
+    padding: 0.5rem 0 0;
   }
 
   .header {
-    padding-inline: 1rem;
-  }
-
-  .header .controls {
     display: none;
-  }
-
-  .header h1 {
-    font-size: 2.15rem;
   }
 
   .desktopStage,
@@ -250,8 +257,12 @@
 
   .mobileScroller {
     display: flex;
+    width: min(100%, calc(100dvh - 15.7rem));
     min-width: 0;
     min-height: 0;
+    aspect-ratio: 1;
+    align-self: center;
+    justify-self: center;
     overflow-x: auto;
     overscroll-behavior-x: contain;
     scroll-snap-type: x mandatory;
@@ -273,15 +284,6 @@
     scroll-snap-stop: always;
   }
 
-  .mobileSlide::after {
-    position: absolute;
-    inset: auto 0 0;
-    height: 20%;
-    content: "";
-    background: linear-gradient(0deg, rgb(10 9 8 / 0.45), transparent);
-    pointer-events: none;
-  }
-
   .mobileControls {
     display: flex;
     justify-content: center;
@@ -299,11 +301,7 @@
 }
 
 @media (max-height: 650px) and (max-width: 760px) {
-  .header h1 {
-    font-size: 1.8rem;
-  }
-
-  .kicker {
-    display: none;
+  .mobileScroller {
+    width: min(100%, calc(100dvh - 14.9rem));
   }
 }

--- a/src/app/living-poster/PhotosView.module.css
+++ b/src/app/living-poster/PhotosView.module.css
@@ -3,16 +3,24 @@
   width: min(100%, 92rem);
   height: 100%;
   min-height: 0;
-  grid-template-rows: auto minmax(0, 1fr) clamp(3.2rem, 8vh, 5rem);
-  gap: 0.7rem;
+  grid-template-columns: minmax(0, 1fr) minmax(12.1rem, 14rem);
+  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-areas:
+    "stage controls"
+    "stage previews";
+  gap: 0.7rem clamp(1rem, 2.5vw, 2.5rem);
   margin-inline: auto;
   padding: clamp(0.85rem, 2vw, 1.5rem) clamp(1rem, 3vw, 2.8rem);
+  overflow: hidden;
 }
 
 .header {
+  grid-area: controls;
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  border-left: 1px solid var(--color-rule);
+  padding-left: 1rem;
 }
 
 .visuallyHidden {
@@ -63,19 +71,18 @@
 }
 
 .stageSlot {
+  grid-area: stage;
   display: grid;
   min-width: 0;
   min-height: 0;
   place-items: center;
+  overflow: hidden;
 }
 
 .desktopStage {
   position: relative;
-  width: auto;
-  max-width: 100%;
+  width: 100%;
   height: 100%;
-  max-height: 100%;
-  aspect-ratio: 1;
   overflow: hidden;
   border: 1px solid rgb(244 228 184 / 0.18);
   padding: 0;
@@ -94,13 +101,19 @@
 }
 
 .thumbnails {
+  grid-area: previews;
   display: grid;
   min-width: 0;
-  grid-auto-columns: clamp(3.2rem, 8vh, 5rem);
-  grid-auto-flow: column;
-  justify-content: center;
-  gap: 0.4rem;
-  overflow-x: auto;
+  min-height: 0;
+  grid-template-columns: repeat(2, 4rem);
+  grid-auto-rows: 4rem;
+  align-content: start;
+  justify-content: end;
+  gap: 0.55rem;
+  border-left: 1px solid var(--color-rule);
+  padding: 0 0.25rem 0 1rem;
+  overflow-x: hidden;
+  overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--color-rule) transparent;
 }
@@ -128,8 +141,7 @@
   object-fit: contain;
 }
 
-.mobileScroller,
-.mobileControls {
+.mobileScroller {
   display: none;
 }
 
@@ -225,27 +237,32 @@
 
 @media (min-width: 761px) and (max-width: 1120px) {
   .view {
-    grid-template-rows: auto minmax(0, 1fr) clamp(3.2rem, 8vh, 4rem);
+    grid-template-columns: minmax(0, 1fr) 12.1rem;
+    gap: 0.7rem 1rem;
   }
 
   .thumbnails {
-    grid-auto-columns: clamp(3.2rem, 8vh, 4rem);
+    grid-template-columns: repeat(2, 3.5rem);
+    grid-auto-rows: 3.5rem;
+    gap: 0.5rem;
   }
 }
 
 @media (max-width: 760px) {
   .view {
-    grid-template-rows: minmax(0, 1fr) 3.25rem auto;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr) 3rem;
+    grid-template-areas:
+      "controls"
+      "stage"
+      "previews";
     gap: 0.45rem;
     padding: 0.5rem 0 0;
   }
 
   .header {
-    display: none;
-  }
-
-  .stageSlot {
-    display: none;
+    border-left: 0;
+    padding-inline: 0.75rem;
   }
 
   .mobileScroller {
@@ -266,6 +283,10 @@
     touch-action: pan-x pinch-zoom;
   }
 
+  .desktopStage {
+    display: none;
+  }
+
   .mobileScroller::-webkit-scrollbar {
     display: none;
   }
@@ -281,11 +302,17 @@
   }
 
   .thumbnails {
-    grid-auto-columns: 3.25rem;
-    justify-content: start;
-    gap: 0.45rem;
-    padding-inline: 0.75rem;
+    grid-template-columns: none;
+    grid-auto-columns: 3rem;
+    grid-auto-rows: 3rem;
+    grid-auto-flow: column;
+    align-content: stretch;
+    justify-content: safe center;
+    gap: 0.375rem;
+    border-left: 0;
+    padding-inline: 0.5rem;
     overflow-x: auto;
+    overflow-y: hidden;
     scroll-padding-inline: 0.75rem;
     scroll-snap-type: x proximity;
     scrollbar-width: none;
@@ -299,14 +326,18 @@
     scroll-snap-align: center;
   }
 
-  .mobileControls {
-    display: flex;
-    justify-content: center;
-    padding: 0 1rem 0.55rem;
+  .controls {
+    gap: 0.3rem;
   }
 
-  .mobileControls .controls {
-    justify-content: center;
+  .controls > span {
+    min-width: 3.4rem;
+    font-size: 0.54rem;
+  }
+
+  .controls button {
+    width: 1.95rem;
+    height: 1.95rem;
   }
 
   .lightboxNavigation span {

--- a/src/app/living-poster/PhotosView.module.css
+++ b/src/app/living-poster/PhotosView.module.css
@@ -225,39 +225,18 @@
 
 @media (min-width: 761px) and (max-width: 1120px) {
   .view {
-    height: 100%;
-    grid-template-rows: auto max-content max-content;
-    align-content: start;
-    padding: 1rem clamp(1.25rem, 4vw, 2.5rem) 2rem;
-    overflow-y: auto;
-    overscroll-behavior-y: contain;
-  }
-
-  .stageSlot {
-    min-height: auto;
-  }
-
-  .desktopStage {
-    width: min(100%, 46rem);
-    max-width: none;
-    height: auto;
-    max-height: none;
+    grid-template-rows: auto minmax(0, 1fr) clamp(3.2rem, 8vh, 4rem);
   }
 
   .thumbnails {
-    grid-auto-columns: auto;
-    grid-auto-flow: row;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    justify-content: stretch;
-    gap: 0.65rem;
-    overflow: visible;
+    grid-auto-columns: clamp(3.2rem, 8vh, 4rem);
   }
 }
 
 @media (max-width: 760px) {
   .view {
-    grid-template-rows: minmax(0, 1fr) auto;
-    gap: 0.6rem;
+    grid-template-rows: minmax(0, 1fr) 3.25rem auto;
+    gap: 0.45rem;
     padding: 0.5rem 0 0;
   }
 
@@ -265,14 +244,16 @@
     display: none;
   }
 
-  .stageSlot,
-  .thumbnails {
+  .stageSlot {
     display: none;
   }
 
   .mobileScroller {
     display: flex;
-    width: min(100%, calc(100dvh - 15.7rem));
+    width: auto;
+    max-width: 100%;
+    height: 100%;
+    max-height: 100%;
     min-width: 0;
     min-height: 0;
     aspect-ratio: 1;
@@ -299,10 +280,29 @@
     scroll-snap-stop: always;
   }
 
+  .thumbnails {
+    grid-auto-columns: 3.25rem;
+    justify-content: start;
+    gap: 0.45rem;
+    padding-inline: 0.75rem;
+    overflow-x: auto;
+    scroll-padding-inline: 0.75rem;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+  }
+
+  .thumbnails::-webkit-scrollbar {
+    display: none;
+  }
+
+  .thumbnails button {
+    scroll-snap-align: center;
+  }
+
   .mobileControls {
     display: flex;
     justify-content: center;
-    padding: 0 1rem 0.7rem;
+    padding: 0 1rem 0.55rem;
   }
 
   .mobileControls .controls {
@@ -312,11 +312,5 @@
   .lightboxNavigation span {
     max-width: 9rem;
     text-align: center;
-  }
-}
-
-@media (max-height: 650px) and (max-width: 760px) {
-  .mobileScroller {
-    width: min(100%, calc(100dvh - 14.9rem));
   }
 }

--- a/src/app/living-poster/PhotosView.module.css
+++ b/src/app/living-poster/PhotosView.module.css
@@ -62,13 +62,20 @@
   background: var(--color-gold);
 }
 
+.stageSlot {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  place-items: center;
+}
+
 .desktopStage {
   position: relative;
-  width: min(100%, calc(100dvh - 18rem));
-  min-height: 0;
+  width: auto;
+  max-width: 100%;
+  height: 100%;
+  max-height: 100%;
   aspect-ratio: 1;
-  align-self: center;
-  justify-self: center;
   overflow: hidden;
   border: 1px solid rgb(244 228 184 / 0.18);
   padding: 0;
@@ -219,14 +226,22 @@
 @media (min-width: 761px) and (max-width: 1120px) {
   .view {
     height: 100%;
-    grid-template-rows: auto auto auto;
+    grid-template-rows: auto max-content max-content;
+    align-content: start;
     padding: 1rem clamp(1.25rem, 4vw, 2.5rem) 2rem;
     overflow-y: auto;
     overscroll-behavior-y: contain;
   }
 
+  .stageSlot {
+    min-height: auto;
+  }
+
   .desktopStage {
     width: min(100%, 46rem);
+    max-width: none;
+    height: auto;
+    max-height: none;
   }
 
   .thumbnails {
@@ -250,7 +265,7 @@
     display: none;
   }
 
-  .desktopStage,
+  .stageSlot,
   .thumbnails {
     display: none;
   }

--- a/src/app/living-poster/PhotosView.tsx
+++ b/src/app/living-poster/PhotosView.tsx
@@ -124,10 +124,9 @@ export function PhotosView() {
   return (
     <section className={styles.view} aria-labelledby="photos-title">
       <div className={styles.header}>
-        <div>
-          <p className={styles.kicker}>Portraits &amp; performances</p>
-          <h1 id="photos-title">Photographs</h1>
-        </div>
+        <h1 id="photos-title" className={styles.visuallyHidden}>
+          Photographs
+        </h1>
         <PhotoControls
           activeIndex={activeIndex}
           onPrevious={() => selectPhoto(activeIndex - 1, true)}
@@ -148,7 +147,7 @@ export function PhotosView() {
           alt={activePhoto.alt}
           fill
           priority
-          sizes="100vw"
+          sizes="(max-width: 1120px) 92vw, 70vh"
           style={{ objectPosition: activePhoto.objectPosition }}
         />
       </button>
@@ -195,7 +194,7 @@ export function PhotosView() {
               alt=""
               fill
               loading="lazy"
-              sizes="10vw"
+              sizes="(max-width: 1120px) 22vw, 10vw"
               style={{ objectPosition: photo.objectPosition }}
             />
           </button>

--- a/src/app/living-poster/PhotosView.tsx
+++ b/src/app/living-poster/PhotosView.tsx
@@ -29,6 +29,7 @@ export function PhotosView() {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
+  const thumbnailScrollerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const pinchRef = useRef<{ distance: number; zoom: number } | null>(null);
 
@@ -65,6 +66,33 @@ export function PhotosView() {
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
   }, [lightboxOpen]);
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+
+    const alignActiveSlide = () => {
+      scroller.scrollTo({
+        left: activeIndex * scroller.clientWidth,
+        behavior: "auto",
+      });
+    };
+
+    const observer = new ResizeObserver(alignActiveSlide);
+    observer.observe(scroller);
+    return () => observer.disconnect();
+  }, [activeIndex]);
+
+  useEffect(() => {
+    const activeThumbnail = thumbnailScrollerRef.current?.children.item(activeIndex);
+    if (!(activeThumbnail instanceof HTMLElement)) return;
+
+    activeThumbnail.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "center",
+    });
+  }, [activeIndex]);
 
   const selectPhoto = (index: number, scrollMobile = false) => {
     const wrappedIndex = (index + photos.length) % photos.length;
@@ -182,21 +210,25 @@ export function PhotosView() {
         ))}
       </div>
 
-      <div className={styles.thumbnails} aria-label="Photograph thumbnails">
+      <div
+        ref={thumbnailScrollerRef}
+        className={styles.thumbnails}
+        aria-label="Photograph thumbnails"
+      >
         {photos.map((photo, index) => (
           <button
             key={photo.src}
             type="button"
             aria-current={index === activeIndex ? "true" : undefined}
             aria-label={`View photograph ${index + 1}`}
-            onClick={() => selectPhoto(index)}
+            onClick={() => selectPhoto(index, true)}
           >
             <Image
               src={photo.src}
               alt=""
               fill
               loading="lazy"
-              sizes="(max-width: 1120px) 22vw, 10vw"
+              sizes="(max-width: 760px) 3.25rem, (max-width: 1120px) 4rem, 5rem"
               style={{ objectPosition: photo.objectPosition }}
             />
           </button>

--- a/src/app/living-poster/PhotosView.tsx
+++ b/src/app/living-poster/PhotosView.tsx
@@ -135,22 +135,24 @@ export function PhotosView() {
         />
       </div>
 
-      <button
-        type="button"
-        className={styles.desktopStage}
-        aria-label={`View photograph ${activeIndex + 1} full screen`}
-        onClick={(event) => openLightbox(activeIndex, event.currentTarget)}
-      >
-        <Image
-          key={activePhoto.src}
-          src={activePhoto.src}
-          alt={activePhoto.alt}
-          fill
-          priority
-          sizes="(max-width: 1120px) 92vw, 70vh"
-          style={{ objectPosition: activePhoto.objectPosition }}
-        />
-      </button>
+      <div className={styles.stageSlot}>
+        <button
+          type="button"
+          className={styles.desktopStage}
+          aria-label={`View photograph ${activeIndex + 1} full screen`}
+          onClick={(event) => openLightbox(activeIndex, event.currentTarget)}
+        >
+          <Image
+            key={activePhoto.src}
+            src={activePhoto.src}
+            alt={activePhoto.alt}
+            fill
+            priority
+            sizes="(max-width: 1120px) 92vw, 70vh"
+            style={{ objectPosition: activePhoto.objectPosition }}
+          />
+        </button>
+      </div>
 
       <div
         ref={scrollerRef}

--- a/src/app/living-poster/PhotosView.tsx
+++ b/src/app/living-poster/PhotosView.tsx
@@ -180,34 +180,34 @@ export function PhotosView() {
             style={{ objectPosition: activePhoto.objectPosition }}
           />
         </button>
-      </div>
 
-      <div
-        ref={scrollerRef}
-        className={styles.mobileScroller}
-        onScroll={(event) => {
-          const width = event.currentTarget.clientWidth;
-          if (width) setActiveIndex(Math.round(event.currentTarget.scrollLeft / width));
-        }}
-      >
-        {photos.map((photo, index) => (
-          <button
-            key={photo.src}
-            type="button"
-            className={styles.mobileSlide}
-            aria-label={`View photograph ${index + 1} full screen`}
-            onClick={(event) => openLightbox(index, event.currentTarget)}
-          >
-            <Image
-              src={photo.src}
-              alt={photo.alt}
-              fill
-              loading={index < 2 ? "eager" : "lazy"}
-              sizes="(max-width: 760px) 100vw, 1px"
-              style={{ objectPosition: photo.objectPosition }}
-            />
-          </button>
-        ))}
+        <div
+          ref={scrollerRef}
+          className={styles.mobileScroller}
+          onScroll={(event) => {
+            const width = event.currentTarget.clientWidth;
+            if (width) setActiveIndex(Math.round(event.currentTarget.scrollLeft / width));
+          }}
+        >
+          {photos.map((photo, index) => (
+            <button
+              key={photo.src}
+              type="button"
+              className={styles.mobileSlide}
+              aria-label={`View photograph ${index + 1} full screen`}
+              onClick={(event) => openLightbox(index, event.currentTarget)}
+            >
+              <Image
+                src={photo.src}
+                alt={photo.alt}
+                fill
+                loading={index < 2 ? "eager" : "lazy"}
+                sizes="(max-width: 760px) 100vw, 1px"
+                style={{ objectPosition: photo.objectPosition }}
+              />
+            </button>
+          ))}
+        </div>
       </div>
 
       <div
@@ -233,15 +233,6 @@ export function PhotosView() {
             />
           </button>
         ))}
-      </div>
-
-      <div className={styles.mobileControls}>
-        <PhotoControls
-          activeIndex={activeIndex}
-          onPrevious={() => selectPhoto(activeIndex - 1, true)}
-          onNext={() => selectPhoto(activeIndex + 1, true)}
-          onExpand={() => setLightboxOpen(true)}
-        />
       </div>
 
       <dialog

--- a/src/app/living-poster/PhotosView.tsx
+++ b/src/app/living-poster/PhotosView.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import Image from "next/image";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Maximize2,
+  RotateCcw,
+  X,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+import {
+  type SyntheticEvent,
+  type TouchEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { photos } from "./media";
+import styles from "./PhotosView.module.css";
+
+const clampZoom = (value: number) => Math.min(3, Math.max(1, value));
+
+export function PhotosView() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [zoom, setZoom] = useState(1);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const pinchRef = useRef<{ distance: number; zoom: number } | null>(null);
+
+  const activePhoto = photos[activeIndex];
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (lightboxOpen) {
+      if (!dialog.open) dialog.showModal();
+      window.requestAnimationFrame(() => closeRef.current?.focus());
+    } else if (dialog.open) {
+      dialog.close();
+    }
+  }, [lightboxOpen]);
+
+  useEffect(() => {
+    if (!lightboxOpen) return;
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        setZoom(1);
+        setActiveIndex((index) => (index - 1 + photos.length) % photos.length);
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        setZoom(1);
+        setActiveIndex((index) => (index + 1) % photos.length);
+      }
+    };
+
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [lightboxOpen]);
+
+  const selectPhoto = (index: number, scrollMobile = false) => {
+    const wrappedIndex = (index + photos.length) % photos.length;
+    setZoom(1);
+    setActiveIndex(wrappedIndex);
+    if (scrollMobile) {
+      scrollerRef.current?.scrollTo({
+        left: wrappedIndex * scrollerRef.current.clientWidth,
+        behavior: "smooth",
+      });
+    }
+  };
+
+  const openLightbox = (index: number, trigger: HTMLButtonElement) => {
+    triggerRef.current = trigger;
+    setZoom(1);
+    setActiveIndex(index);
+    setLightboxOpen(true);
+  };
+
+  const closeLightbox = () => {
+    setLightboxOpen(false);
+    setZoom(1);
+    window.requestAnimationFrame(() => triggerRef.current?.focus());
+  };
+
+  const handleDialogClose = () => {
+    setLightboxOpen(false);
+    setZoom(1);
+    window.requestAnimationFrame(() => triggerRef.current?.focus());
+  };
+
+  const handleDialogCancel = (event: SyntheticEvent<HTMLDialogElement>) => {
+    event.preventDefault();
+    closeLightbox();
+  };
+
+  const touchDistance = (event: TouchEvent) => {
+    const [first, second] = Array.from(event.touches);
+    if (!first || !second) return 0;
+    return Math.hypot(second.clientX - first.clientX, second.clientY - first.clientY);
+  };
+
+  const handleTouchStart = (event: TouchEvent) => {
+    if (event.touches.length === 2) {
+      pinchRef.current = { distance: touchDistance(event), zoom };
+    }
+  };
+
+  const handleTouchMove = (event: TouchEvent) => {
+    if (event.touches.length !== 2 || !pinchRef.current) return;
+    event.preventDefault();
+    const distance = touchDistance(event);
+    setZoom(clampZoom(pinchRef.current.zoom * (distance / pinchRef.current.distance)));
+  };
+
+  return (
+    <section className={styles.view} aria-labelledby="photos-title">
+      <div className={styles.header}>
+        <div>
+          <p className={styles.kicker}>Portraits &amp; performances</p>
+          <h1 id="photos-title">Photographs</h1>
+        </div>
+        <PhotoControls
+          activeIndex={activeIndex}
+          onPrevious={() => selectPhoto(activeIndex - 1, true)}
+          onNext={() => selectPhoto(activeIndex + 1, true)}
+          onExpand={() => setLightboxOpen(true)}
+        />
+      </div>
+
+      <button
+        type="button"
+        className={styles.desktopStage}
+        aria-label={`View photograph ${activeIndex + 1} full screen`}
+        onClick={(event) => openLightbox(activeIndex, event.currentTarget)}
+      >
+        <Image
+          key={activePhoto.src}
+          src={activePhoto.src}
+          alt={activePhoto.alt}
+          fill
+          priority
+          sizes="100vw"
+          style={{ objectPosition: activePhoto.objectPosition }}
+        />
+      </button>
+
+      <div
+        ref={scrollerRef}
+        className={styles.mobileScroller}
+        onScroll={(event) => {
+          const width = event.currentTarget.clientWidth;
+          if (width) setActiveIndex(Math.round(event.currentTarget.scrollLeft / width));
+        }}
+      >
+        {photos.map((photo, index) => (
+          <button
+            key={photo.src}
+            type="button"
+            className={styles.mobileSlide}
+            aria-label={`View photograph ${index + 1} full screen`}
+            onClick={(event) => openLightbox(index, event.currentTarget)}
+          >
+            <Image
+              src={photo.src}
+              alt={photo.alt}
+              fill
+              loading={index < 2 ? "eager" : "lazy"}
+              sizes="(max-width: 760px) 100vw, 1px"
+              style={{ objectPosition: photo.objectPosition }}
+            />
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.thumbnails} aria-label="Photograph thumbnails">
+        {photos.map((photo, index) => (
+          <button
+            key={photo.src}
+            type="button"
+            aria-current={index === activeIndex ? "true" : undefined}
+            aria-label={`View photograph ${index + 1}`}
+            onClick={() => selectPhoto(index)}
+          >
+            <Image
+              src={photo.src}
+              alt=""
+              fill
+              loading="lazy"
+              sizes="10vw"
+              style={{ objectPosition: photo.objectPosition }}
+            />
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.mobileControls}>
+        <PhotoControls
+          activeIndex={activeIndex}
+          onPrevious={() => selectPhoto(activeIndex - 1, true)}
+          onNext={() => selectPhoto(activeIndex + 1, true)}
+          onExpand={() => setLightboxOpen(true)}
+        />
+      </div>
+
+      <dialog
+        ref={dialogRef}
+        className={styles.lightbox}
+        aria-label="Photograph viewer"
+        onClose={handleDialogClose}
+        onCancel={handleDialogCancel}
+      >
+        <div className={styles.lightboxFrame}>
+          <div className={styles.lightboxToolbar}>
+            <span aria-live="polite">
+              {String(activeIndex + 1).padStart(2, "0")} / {String(photos.length).padStart(2, "0")}
+            </span>
+            <div>
+              <button
+                type="button"
+                aria-label="Zoom out"
+                disabled={zoom <= 1}
+                onClick={() => setZoom((value) => clampZoom(value - 0.5))}
+              >
+                <ZoomOut size={20} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                aria-label="Reset zoom"
+                disabled={zoom === 1}
+                onClick={() => setZoom(1)}
+              >
+                <RotateCcw size={18} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                aria-label="Zoom in"
+                disabled={zoom >= 3}
+                onClick={() => setZoom((value) => clampZoom(value + 0.5))}
+              >
+                <ZoomIn size={20} aria-hidden="true" />
+              </button>
+              <button
+                ref={closeRef}
+                type="button"
+                aria-label="Close photograph viewer"
+                onClick={closeLightbox}
+              >
+                <X size={21} aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+
+          <div
+            className={styles.lightboxStage}
+            onDoubleClick={() => setZoom((value) => (value === 1 ? 2 : 1))}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={() => {
+              pinchRef.current = null;
+            }}
+          >
+            <div className={styles.lightboxImage} style={{ transform: `scale(${zoom})` }}>
+              <Image
+                key={activePhoto.src}
+                src={activePhoto.src}
+                alt={activePhoto.alt}
+                fill
+                sizes="100vw"
+                draggable={false}
+              />
+            </div>
+          </div>
+
+          <div className={styles.lightboxNavigation}>
+            <button
+              type="button"
+              aria-label="Previous photograph"
+              onClick={() => selectPhoto(activeIndex - 1)}
+            >
+              <ChevronLeft size={22} aria-hidden="true" />
+            </button>
+            <span>Pinch or double-tap to zoom</span>
+            <button
+              type="button"
+              aria-label="Next photograph"
+              onClick={() => selectPhoto(activeIndex + 1)}
+            >
+              <ChevronRight size={22} aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+      </dialog>
+    </section>
+  );
+}
+
+function PhotoControls({
+  activeIndex,
+  onPrevious,
+  onNext,
+  onExpand,
+}: {
+  activeIndex: number;
+  onPrevious: () => void;
+  onNext: () => void;
+  onExpand: () => void;
+}) {
+  return (
+    <div className={styles.controls}>
+      <span aria-live="polite">
+        {String(activeIndex + 1).padStart(2, "0")} / {String(photos.length).padStart(2, "0")}
+      </span>
+      <button type="button" aria-label="Previous photograph" onClick={onPrevious}>
+        <ChevronLeft size={20} aria-hidden="true" />
+      </button>
+      <button type="button" aria-label="Next photograph" onClick={onNext}>
+        <ChevronRight size={20} aria-hidden="true" />
+      </button>
+      <button type="button" aria-label="View photograph full screen" onClick={onExpand}>
+        <Maximize2 size={18} aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/src/app/living-poster/PosterHome.module.css
+++ b/src/app/living-poster/PosterHome.module.css
@@ -1,0 +1,96 @@
+.poster {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+.copy {
+  position: absolute;
+  inset: 0 auto 0 0;
+  display: flex;
+  width: min(36%, 34rem);
+  min-width: 19rem;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(1.4rem, 3vw, 2.8rem) 1rem clamp(1.4rem, 3vw, 2.8rem) clamp(1.25rem, 3vw, 2.8rem);
+}
+
+.eyebrow,
+.location {
+  margin: 0;
+  color: var(--color-paper-muted);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  margin-bottom: 0.8rem;
+  color: var(--color-gold);
+}
+
+.copy h1 {
+  max-width: 5.5ch;
+  margin: 0;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(4.8rem, 8vw, 8.3rem);
+  font-weight: 400;
+  line-height: 0.73;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+}
+
+.copy h1 span {
+  color: var(--color-rust);
+}
+
+.supporting {
+  max-width: 22rem;
+  margin: 1.1rem 0 0;
+  font-family: var(--font-serif), Georgia, serif;
+  font-size: clamp(1.05rem, 1.8vw, 1.4rem);
+  font-style: italic;
+  line-height: 1.12;
+}
+
+.location {
+  margin-top: 1.25rem;
+}
+
+@media (max-width: 760px) {
+  .copy {
+    inset: auto 1rem 1.15rem;
+    width: auto;
+    min-width: 0;
+    padding: 0;
+  }
+
+  .eyebrow {
+    display: none;
+  }
+
+  .copy h1 {
+    font-size: clamp(4rem, 19vw, 5.4rem);
+  }
+
+  .supporting {
+    max-width: 18rem;
+    margin-top: 0.75rem;
+    font-size: 1.05rem;
+  }
+
+  .location {
+    display: none;
+  }
+}
+
+@media (max-height: 690px) and (max-width: 760px) {
+  .copy h1 {
+    font-size: clamp(3.25rem, 15.5vw, 4.4rem);
+  }
+
+  .supporting {
+    max-width: 16rem;
+    font-size: 0.94rem;
+  }
+}

--- a/src/app/living-poster/PosterHome.module.css
+++ b/src/app/living-poster/PosterHome.module.css
@@ -14,7 +14,6 @@
   padding: clamp(1.4rem, 3vw, 2.8rem) 1rem clamp(1.4rem, 3vw, 2.8rem) clamp(1.25rem, 3vw, 2.8rem);
 }
 
-.eyebrow,
 .location {
   margin: 0;
   color: var(--color-paper-muted);
@@ -24,16 +23,11 @@
   text-transform: uppercase;
 }
 
-.eyebrow {
-  margin-bottom: 0.8rem;
-  color: var(--color-gold);
-}
-
 .copy h1 {
   max-width: 5.5ch;
   margin: 0;
   font-family: var(--font-display), sans-serif;
-  font-size: clamp(4.8rem, 8vw, 8.3rem);
+  font-size: clamp(4.4rem, 6.5vw, 6.9rem);
   font-weight: 400;
   line-height: 0.73;
   letter-spacing: -0.04em;
@@ -57,16 +51,31 @@
   margin-top: 1.25rem;
 }
 
+@media (min-width: 761px) and (max-width: 1120px) {
+  .copy {
+    inset: auto auto clamp(1.4rem, 4vw, 2.6rem) clamp(1.4rem, 4vw, 2.6rem);
+    width: min(48%, 28rem);
+    min-width: 18rem;
+    justify-content: flex-end;
+    padding: 0;
+  }
+
+  .copy h1 {
+    font-size: clamp(4.25rem, 9.5vw, 6.25rem);
+  }
+
+  .supporting {
+    max-width: 19rem;
+    font-size: clamp(1rem, 2.3vw, 1.22rem);
+  }
+}
+
 @media (max-width: 760px) {
   .copy {
     inset: auto 1rem 1.15rem;
     width: auto;
     min-width: 0;
     padding: 0;
-  }
-
-  .eyebrow {
-    display: none;
   }
 
   .copy h1 {

--- a/src/app/living-poster/PosterHome.tsx
+++ b/src/app/living-poster/PosterHome.tsx
@@ -1,0 +1,23 @@
+import data from "../data.json";
+import styles from "./PosterHome.module.css";
+
+export function PosterHome() {
+  return (
+    <section className={styles.poster} aria-labelledby="poster-title">
+      <div className={styles.copy}>
+        <p className={styles.eyebrow}>Jazz vocalist &amp; guitarist</p>
+        <h1 id="poster-title">
+          The Great
+          <br />
+          American
+          <br />
+          Songbook,
+          <br />
+          <span>Live</span>
+        </h1>
+        <p className={styles.supporting}>{data.hero.supportingCopy}</p>
+        <p className={styles.location}>Northeast Ohio · Available for private events</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/living-poster/PosterHome.tsx
+++ b/src/app/living-poster/PosterHome.tsx
@@ -5,7 +5,6 @@ export function PosterHome() {
   return (
     <section className={styles.poster} aria-labelledby="poster-title">
       <div className={styles.copy}>
-        <p className={styles.eyebrow}>Jazz vocalist &amp; guitarist</p>
         <h1 id="poster-title">
           The Great
           <br />
@@ -16,7 +15,7 @@ export function PosterHome() {
           <span>Live</span>
         </h1>
         <p className={styles.supporting}>{data.hero.supportingCopy}</p>
-        <p className={styles.location}>Northeast Ohio · Available for private events</p>
+        <p className={styles.location}>Northeast Ohio</p>
       </div>
     </section>
   );

--- a/src/app/living-poster/VideosView.module.css
+++ b/src/app/living-poster/VideosView.module.css
@@ -1,0 +1,293 @@
+.view {
+  display: grid;
+  width: min(100%, 92rem);
+  height: 100%;
+  min-height: 0;
+  grid-template-columns: minmax(0, 1.55fr) minmax(17rem, 0.65fr);
+  gap: clamp(1rem, 2.5vw, 2.5rem);
+  margin-inline: auto;
+  padding: clamp(0.85rem, 2vw, 1.5rem) clamp(1rem, 3vw, 2.8rem);
+  overflow: hidden;
+}
+.primary {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-self: stretch;
+}
+
+.kicker {
+  margin: 0;
+  color: var(--color-gold);
+  font-size: 0.64rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.frame {
+  position: relative;
+  width: 100%;
+  max-height: 100%;
+  aspect-ratio: 16 / 9;
+  align-self: center;
+  overflow: hidden;
+  border: 1px solid rgb(244 228 184 / 0.2);
+  background: #050504;
+}
+
+.frame iframe,
+.playButton {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.playButton {
+  padding: 0;
+  color: var(--color-ink);
+  background: #050504;
+}
+
+.playButton::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: rgb(10 9 8 / 0.18);
+  transition: background-color 180ms ease;
+}
+
+.playButton > img {
+  object-fit: cover;
+  filter: saturate(0.72) contrast(1.05) sepia(0.11);
+  transition: filter 200ms ease, transform 300ms ease;
+}
+
+.playButton > span {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  z-index: 1;
+  display: grid;
+  width: 4.25rem;
+  height: 4.25rem;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--color-gold);
+  transform: translate(-50%, -50%);
+  transition: transform 180ms ease, background-color 180ms ease;
+}
+
+.playButton:hover > img,
+.playButton:focus-visible > img {
+  filter: saturate(0.92) contrast(1.05);
+  transform: scale(1.02);
+}
+
+.playButton:hover > span,
+.playButton:focus-visible > span {
+  background: var(--color-paper);
+  transform: translate(-50%, -50%) scale(1.05);
+}
+
+.caption {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+}
+
+.caption h1 {
+  min-width: 0;
+  margin: 0;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(2.1rem, 4.5vw, 4.4rem);
+  font-weight: 400;
+  line-height: 0.85;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.controls > span {
+  min-width: 4rem;
+  color: var(--color-paper-muted);
+  font-size: 0.6rem;
+  letter-spacing: 0.12em;
+  text-align: center;
+}
+
+.controls button {
+  display: grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  place-items: center;
+  border: 1px solid var(--color-rule);
+  padding: 0;
+  color: var(--color-paper);
+  background: #15110e;
+}
+
+.controls button:hover,
+.controls button:focus-visible {
+  border-color: var(--color-gold);
+  color: var(--color-ink);
+  background: var(--color-gold);
+}
+
+.playlist {
+  align-self: center;
+  min-width: 0;
+  max-height: 100%;
+  margin: 0;
+  border-left: 1px solid var(--color-rule);
+  padding: 0 0 0 1rem;
+  overflow-y: auto;
+  list-style: none;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-rule) transparent;
+}
+
+.playlist li {
+  border-bottom: 1px solid var(--color-rule);
+}
+
+.playlist button {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(5.5rem, 7.4rem) 1.4rem minmax(0, 1fr);
+  align-items: center;
+  gap: 0.65rem;
+  border: 0;
+  padding: 0.5rem 0;
+  color: var(--color-paper-muted);
+  background: transparent;
+  text-align: left;
+}
+
+.playlist button:hover,
+.playlist button:focus-visible,
+.playlist button[aria-current="true"] {
+  color: var(--color-gold);
+}
+
+.thumbnail {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: #050504;
+}
+
+.thumbnail img {
+  object-fit: cover;
+  filter: saturate(0.62) sepia(0.12);
+}
+
+.number {
+  color: var(--color-rust);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+}
+
+.playlist strong {
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(0.95rem, 1.3vw, 1.25rem);
+  font-weight: 400;
+  line-height: 0.93;
+  text-transform: uppercase;
+}
+
+@media (max-width: 760px) {
+  .view {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    overflow-y: auto;
+    overscroll-behavior-y: contain;
+  }
+
+  .primary {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    display: block;
+    padding: 0.65rem 1rem 0.7rem;
+    border-bottom: 1px solid var(--color-rule);
+    background: #0d0b09;
+  }
+
+  .kicker {
+    margin-bottom: 0.5rem;
+  }
+
+  .frame {
+    aspect-ratio: 16 / 9;
+  }
+
+  .playButton > span {
+    width: 3.25rem;
+    height: 3.25rem;
+  }
+
+  .caption {
+    margin-top: 0.55rem;
+  }
+
+  .caption h1 {
+    font-size: clamp(1.55rem, 7.5vw, 2.2rem);
+  }
+
+  .controls {
+    gap: 0.3rem;
+  }
+
+  .controls > span {
+    min-width: 3.4rem;
+    font-size: 0.54rem;
+  }
+
+  .controls button {
+    width: 1.95rem;
+    height: 1.95rem;
+  }
+
+  .playlist {
+    max-height: none;
+    border-left: 0;
+    padding: 0 1rem 0.75rem;
+    overflow: visible;
+  }
+
+  .playlist button {
+    grid-template-columns: 5.8rem 1.3rem minmax(0, 1fr);
+    padding: 0.55rem 0;
+  }
+
+  .playlist strong {
+    font-size: 1rem;
+  }
+}
+
+@media (max-height: 650px) and (max-width: 760px) {
+  .primary {
+    padding-top: 0.45rem;
+  }
+
+  .kicker {
+    display: none;
+  }
+
+  .frame {
+    width: min(100%, 42vh);
+    margin-inline: auto;
+  }
+}

--- a/src/app/living-poster/VideosView.module.css
+++ b/src/app/living-poster/VideosView.module.css
@@ -8,23 +8,15 @@
   margin-inline: auto;
   padding: clamp(0.85rem, 2vw, 1.5rem) clamp(1rem, 3vw, 2.8rem);
   overflow: hidden;
+  align-items: start;
 }
 .primary {
-  display: grid;
+  display: flex;
   min-width: 0;
   min-height: 0;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  flex-direction: column;
   gap: 0.65rem;
-  align-self: stretch;
-}
-
-.kicker {
-  margin: 0;
-  color: var(--color-gold);
-  font-size: 0.64rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  align-self: start;
 }
 
 .frame {
@@ -32,7 +24,7 @@
   width: 100%;
   max-height: 100%;
   aspect-ratio: 16 / 9;
-  align-self: center;
+  align-self: start;
   overflow: hidden;
   border: 1px solid rgb(244 228 184 / 0.2);
   background: #050504;
@@ -144,7 +136,7 @@
 }
 
 .playlist {
-  align-self: center;
+  align-self: start;
   min-width: 0;
   max-height: 100%;
   margin: 0;
@@ -205,6 +197,67 @@
   text-transform: uppercase;
 }
 
+@media (min-width: 761px) and (max-width: 1120px) {
+  .view {
+    display: block;
+    width: min(100%, 58rem);
+    height: 100%;
+    padding: 1.25rem clamp(1.25rem, 4vw, 2.5rem) 2rem;
+    overflow-y: auto;
+    overscroll-behavior-y: contain;
+  }
+
+  .primary {
+    display: block;
+  }
+
+  .frame {
+    width: 100%;
+  }
+
+  .caption {
+    margin-top: 0.75rem;
+  }
+
+  .caption h1 {
+    font-size: clamp(2.25rem, 6vw, 3.6rem);
+  }
+
+  .playlist {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    max-height: none;
+    margin-top: 1.5rem;
+    border-left: 0;
+    padding: 0;
+    overflow: visible;
+  }
+
+  .playlist li {
+    border: 1px solid var(--color-rule);
+  }
+
+  .playlist button {
+    height: 100%;
+    grid-template-columns: 1.4rem minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    align-items: start;
+    gap: 0.65rem;
+    padding: 0.55rem;
+  }
+
+  .thumbnail {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .playlist strong {
+    font-size: clamp(1.1rem, 2.8vw, 1.5rem);
+    line-height: 1;
+  }
+}
+
 @media (max-width: 760px) {
   .view {
     display: block;
@@ -223,10 +276,6 @@
     padding: 0.65rem 1rem 0.7rem;
     border-bottom: 1px solid var(--color-rule);
     background: #0d0b09;
-  }
-
-  .kicker {
-    margin-bottom: 0.5rem;
   }
 
   .frame {
@@ -261,6 +310,7 @@
   }
 
   .playlist {
+    display: block;
     max-height: none;
     border-left: 0;
     padding: 0 1rem 0.75rem;
@@ -269,7 +319,14 @@
 
   .playlist button {
     grid-template-columns: 5.8rem 1.3rem minmax(0, 1fr);
+    grid-template-rows: auto;
+    align-items: center;
     padding: 0.55rem 0;
+  }
+
+  .thumbnail {
+    grid-column: auto;
+    width: auto;
   }
 
   .playlist strong {
@@ -280,10 +337,6 @@
 @media (max-height: 650px) and (max-width: 760px) {
   .primary {
     padding-top: 0.45rem;
-  }
-
-  .kicker {
-    display: none;
   }
 
   .frame {

--- a/src/app/living-poster/VideosView.tsx
+++ b/src/app/living-poster/VideosView.tsx
@@ -27,7 +27,6 @@ export function VideosView() {
   return (
     <section className={styles.view} aria-labelledby="videos-title">
       <div className={styles.primary}>
-        <p className={styles.kicker}>Live performances</p>
         <div className={styles.frame}>
           {playingId === activeVideo.id ? (
             <iframe
@@ -49,7 +48,7 @@ export function VideosView() {
                 alt=""
                 fill
                 priority
-                sizes="(max-width: 760px) 100vw, 68vw"
+                sizes="(max-width: 1120px) 100vw, 68vw"
               />
               <span aria-hidden="true">
                 <Play size={26} fill="currentColor" />
@@ -98,7 +97,7 @@ export function VideosView() {
                     alt=""
                     fill
                     loading="lazy"
-                    sizes="(max-width: 760px) 6rem, 8rem"
+                    sizes="(max-width: 760px) 6rem, (max-width: 1120px) 44vw, 8rem"
                   />
                 </span>
                 <span className={styles.number}>{String(index + 1).padStart(2, "0")}</span>

--- a/src/app/living-poster/VideosView.tsx
+++ b/src/app/living-poster/VideosView.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Image from "next/image";
+import { ChevronLeft, ChevronRight, Play } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import data from "../data.json";
+import styles from "./VideosView.module.css";
+
+const videos = data.videos.map(([title, id]) => ({ title, id }));
+
+export function VideosView() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const requestedIndex = videos.findIndex((video) => video.id === searchParams.get("watch"));
+  const activeIndex = requestedIndex >= 0 ? requestedIndex : 0;
+  const activeVideo = videos[activeIndex];
+  const [playingId, setPlayingId] = useState<string | null>(null);
+
+  const selectVideo = (index: number, play = false) => {
+    const wrappedIndex = (index + videos.length) % videos.length;
+    const video = videos[wrappedIndex];
+    router.push(`/videos?watch=${encodeURIComponent(video.id)}`, { scroll: false });
+    setPlayingId(play ? video.id : null);
+  };
+
+  return (
+    <section className={styles.view} aria-labelledby="videos-title">
+      <div className={styles.primary}>
+        <p className={styles.kicker}>Live performances</p>
+        <div className={styles.frame}>
+          {playingId === activeVideo.id ? (
+            <iframe
+              key={activeVideo.id}
+              src={`https://www.youtube-nocookie.com/embed/${activeVideo.id}?autoplay=1&rel=0&playsinline=1`}
+              title={activeVideo.title}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowFullScreen
+            />
+          ) : (
+            <button
+              type="button"
+              className={styles.playButton}
+              aria-label={`Play ${activeVideo.title}`}
+              onClick={() => setPlayingId(activeVideo.id)}
+            >
+              <Image
+                src={`https://img.youtube.com/vi/${activeVideo.id}/maxresdefault.jpg`}
+                alt=""
+                fill
+                priority
+                sizes="(max-width: 760px) 100vw, 68vw"
+              />
+              <span aria-hidden="true">
+                <Play size={26} fill="currentColor" />
+              </span>
+            </button>
+          )}
+        </div>
+
+        <div className={styles.caption}>
+          <h1 id="videos-title">{activeVideo.title}</h1>
+          <div className={styles.controls}>
+            <span aria-live="polite">
+              {String(activeIndex + 1).padStart(2, "0")} / {String(videos.length).padStart(2, "0")}
+            </span>
+            <button
+              type="button"
+              aria-label="Previous video"
+              onClick={() => selectVideo(activeIndex - 1)}
+            >
+              <ChevronLeft size={20} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              aria-label="Next video"
+              onClick={() => selectVideo(activeIndex + 1)}
+            >
+              <ChevronRight size={20} aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <ol className={styles.playlist} aria-label="Performance videos">
+        {videos.map((video, index) => {
+          const isActive = index === activeIndex;
+          return (
+            <li key={video.id}>
+              <button
+                type="button"
+                aria-current={isActive ? "true" : undefined}
+                onClick={() => selectVideo(index, true)}
+              >
+                <span className={styles.thumbnail}>
+                  <Image
+                    src={`https://img.youtube.com/vi/${video.id}/mqdefault.jpg`}
+                    alt=""
+                    fill
+                    loading="lazy"
+                    sizes="(max-width: 760px) 6rem, 8rem"
+                  />
+                </span>
+                <span className={styles.number}>{String(index + 1).padStart(2, "0")}</span>
+                <strong>{video.title}</strong>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/src/app/living-poster/media.ts
+++ b/src/app/living-poster/media.ts
@@ -1,0 +1,55 @@
+export type Photo = {
+  alt: string;
+  height: number;
+  objectPosition?: string;
+  src: string;
+  width: number;
+};
+
+export const photos: Photo[] = [
+  {
+    src: "/images/photos/web/street-portrait.webp",
+    alt: "Gary Dacanay standing with a sunburst hollow-body guitar inside an ornate atrium.",
+    width: 1467,
+    height: 2200,
+    objectPosition: "50% 30%",
+  },
+  {
+    src: "/images/photos/web/grand-entrance.webp",
+    alt: "Gary Dacanay leaping with a sunburst hollow-body guitar beneath an ornate glass ceiling.",
+    width: 1467,
+    height: 2200,
+    objectPosition: "50% 44%",
+  },
+  {
+    src: "/images/photos/web/guitar-portrait.webp",
+    alt: "Gary Dacanay holding a sunburst hollow-body guitar outside a live music venue.",
+    width: 1467,
+    height: 2200,
+    objectPosition: "50% 32%",
+  },
+  {
+    src: "/images/photos/web/city-portrait.webp",
+    alt: "Gary Dacanay posing with his guitar on a brick-paved city street.",
+    width: 1467,
+    height: 2200,
+  },
+  {
+    src: "/images/photos/web/city-guitar-1.webp",
+    alt: "Gary Dacanay smiling with his guitar outside a downtown venue.",
+    width: 1467,
+    height: 2200,
+  },
+  {
+    src: "/images/photos/web/city-guitar-2.webp",
+    alt: "Gary Dacanay holding his guitar upright on a city street.",
+    width: 1467,
+    height: 2200,
+  },
+  {
+    src: "/images/photos/web/city-guitar-3.webp",
+    alt: "Gary Dacanay holding his guitar in front of downtown buildings and string lights.",
+    width: 1467,
+    height: 2200,
+  },
+];

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { MusicView } from "../living-poster/MusicView";
+
+export const metadata: Metadata = {
+  title: "Music | Gary Dacanay",
+  description: "Listen to featured recordings by jazz vocalist and guitarist Gary Dacanay.",
+};
+
+export default function MusicPage() {
+  return <MusicView />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import data from "./data.json";
 import { siteUrl } from "./content";
-import { HomePage } from "./home/HomePage";
+import { PosterHome } from "./living-poster/PosterHome";
 
 export default function Page() {
   const personSchema = {
@@ -20,7 +20,7 @@ export default function Page() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
       />
-      <HomePage />
+      <PosterHome />
     </>
   );
 }

--- a/src/app/photos/page.tsx
+++ b/src/app/photos/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { PhotosView } from "../living-poster/PhotosView";
+
+export const metadata: Metadata = {
+  title: "Photos | Gary Dacanay",
+  description: "Portrait and performance photography of jazz vocalist and guitarist Gary Dacanay.",
+};
+
+export default function PhotosPage() {
+  return <PhotosView />;
+}

--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { VideosView } from "../living-poster/VideosView";
+
+export const metadata: Metadata = {
+  title: "Videos | Gary Dacanay",
+  description: "Watch live jazz performances by vocalist and guitarist Gary Dacanay.",
+};
+
+export default function VideosPage() {
+  return (
+    <Suspense fallback={null}>
+      <VideosView />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
Closes #37

## Changes

- replace the long-scroll homepage with a persistent, single-screen Living Poster shell
- add route-backed Music, Videos, and Photos canvases with shared desktop and mobile navigation
- mount the existing poster artwork only on the home route
- add desktop video controls and playlist plus a sticky mobile player and scrollable program
- add desktop photo controls/thumbnails, mobile scroll snapping, and a full-screen zoomable lightbox
- contain photo stages within their assigned canvas rows instead of relying on viewport-height subtraction
- give desktop and tablet photos a selected-photo/selection-rail composition modeled on the video hierarchy
- use one shared top-right photo control row across every responsive layout
- place compact desktop and tablet previews in a top-right two-column rail
- collapse mobile to a height-constrained viewer with a centered 48px filmstrip
- keep filmstrip selection synchronized with swiping, controls, resizing, and breakpoint changes
- keep event types, booking email, and Mailchimp newsletter available in focused utility panels
- add real YouTube, Instagram, Facebook, Spotify, and Apple Music icons to the persistent platform rail
- update route metadata, content navigation, and README architecture notes

## Validation

- `pnpm lint`
- `pnpm build`
- `git diff --check`
- fresh browser diagnostics: no warnings or errors

## Manual validation

- desktop: 1440×900 and 1366×768
- short desktop: 1200×600
- tablet: 1024×768 and 768×1024
- tablet breakpoint boundary: 760×900 to 768×1024
- mobile: 390×844
- short mobile: 390×620
- verified the selected image fills the left workspace without overlapping the rail or footer
- verified the desktop/tablet preview rail remains a compact 2×4 grid
- verified top-right controls use the same DOM instance and alignment at every breakpoint
- verified all seven mobile previews remain centered with no horizontal overflow at 390px
- verified photo 7 remains selected and correctly aligned across mobile resizing and the tablet breakpoint
- verified lightbox open/close and focus restoration after the layout restructure
- verified `/`, `/music`, `/videos`, and `/photos`
- verified video query routing and browser Back behavior
- verified poster image is absent from media route DOM
- verified mobile sticky video playback layout
- verified horizontal photo scrolling updates the active counter
- verified lightbox close, previous/next, zoom, and reset controls
- verified booking and newsletter panels, platform links, and Gary’s email

## Docs

- README now describes the shared shell and routed media canvases.
- No additional documentation was needed for the gallery responsive refinements.

## Follow-ups

- A separate browse-all photo grid can be added later if non-sequential gallery browsing becomes necessary.