### PR TITLE
Polish mobile section navigation

### DIFF
--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -29,17 +29,16 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.9rem clamp(1rem, 4vw, 4rem);
-  border-bottom: 1px solid transparent;
   transition:
     background-color 180ms ease,
-    border-color 180ms ease,
+    -webkit-backdrop-filter 180ms ease,
     backdrop-filter 180ms ease;
 }
 
 .navScrolled {
-  border-color: var(--color-rule);
   background: rgb(11 10 9 / 0.9);
-  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
 }
 
 .brand,
@@ -945,10 +944,6 @@
 @media (max-width: 899px) {
   .site {
     padding-bottom: calc(4.5rem + env(safe-area-inset-bottom));
-  }
-
-  .navScrolled {
-    backdrop-filter: none;
   }
 
   .desktopNavigation {

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -957,10 +957,9 @@
 
   .mobileBooking {
     display: inline-flex;
-    min-height: 2.6rem;
     align-items: center;
     justify-content: center;
-    padding: 0.65rem 0.8rem;
+    padding: 0.48rem 0.85rem;
     color: var(--color-ink);
     background: var(--color-gold);
     font-family: var(--font-display), sans-serif;

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -94,6 +94,10 @@
   padding: 0.65rem 1rem !important;
 }
 
+.mobileBooking {
+  display: none;
+}
+
 .mobileTabs {
   display: none;
 }
@@ -951,6 +955,30 @@
     display: none;
   }
 
+  .mobileBooking {
+    display: inline-flex;
+    min-height: 2.6rem;
+    align-items: center;
+    justify-content: center;
+    padding: 0.65rem 0.8rem;
+    color: var(--color-ink);
+    background: var(--color-gold);
+    font-family: var(--font-display), sans-serif;
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    line-height: 1;
+    text-transform: uppercase;
+    transition:
+      color 160ms ease,
+      background-color 160ms ease;
+  }
+
+  .mobileBooking:hover,
+  .mobileBooking:focus-visible {
+    color: var(--color-ink);
+    background: var(--color-paper);
+  }
+
   .mobileTabs {
     position: fixed;
     right: 0;
@@ -972,6 +1000,7 @@
     min-height: 4.5rem;
     align-items: center;
     justify-content: center;
+    flex-direction: column;
     gap: 0.35rem;
     border-right: 1px solid var(--color-rule);
     color: var(--color-paper-muted);

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -43,9 +43,7 @@
 }
 
 .brand,
-.desktopNavigation,
-.menuButton,
-.mobileNavigation {
+.desktopNavigation {
   position: relative;
   z-index: 2;
 }
@@ -96,24 +94,8 @@
   padding: 0.65rem 1rem !important;
 }
 
-.menuButton {
+.mobileTabs {
   display: none;
-  width: 2.75rem;
-  height: 2.75rem;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--color-rule);
-  border-radius: 0;
-  color: var(--color-paper);
-  background: transparent;
-}
-
-.mobileNavigation {
-  display: none;
-}
-
-.mobileNavigationLinks {
-  display: contents;
 }
 
 .hero {
@@ -957,6 +939,10 @@
 }
 
 @media (max-width: 899px) {
+  .site {
+    padding-bottom: calc(4.5rem + env(safe-area-inset-bottom));
+  }
+
   .navScrolled {
     backdrop-filter: none;
   }
@@ -965,81 +951,49 @@
     display: none;
   }
 
-  .menuButton {
-    display: inline-flex;
-  }
-
-  .mobileNavigation {
+  .mobileTabs {
     position: fixed;
-    inset: 0;
-    z-index: 1;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 60;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    border-top: 1px solid var(--color-rule);
+    padding-bottom: env(safe-area-inset-bottom);
+    background: rgb(11 10 9 / 0.96);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+  }
+
+  .mobileTabs a {
     display: flex;
-    visibility: hidden;
-    flex-direction: column;
-    padding: 7.75rem clamp(1.5rem, 7vw, 2.5rem) max(1.5rem, env(safe-area-inset-bottom));
-    overflow-y: auto;
-    background: rgb(8 7 6 / 0.88);
-    -webkit-backdrop-filter: blur(18px);
-    backdrop-filter: blur(18px);
-    opacity: 0;
-    transform: translateY(-1rem);
-    transition:
-      visibility 0s linear 200ms,
-      opacity 200ms ease,
-      transform 200ms ease;
-  }
-
-  .mobileNavigationOpen {
-    visibility: visible;
-    opacity: 1;
-    transform: translateY(0);
-    transition-delay: 0s;
-  }
-
-  .mobileNavigationLinks {
-    position: relative;
-    display: flex;
-    align-self: start;
-    flex-direction: column;
-    gap: clamp(1.15rem, 3.2svh, 1.65rem);
-    padding-top: clamp(0.75rem, 5svh, 3rem);
-  }
-
-  .mobileNavigation a {
-    display: block;
-    padding: 0.18rem 0;
+    min-width: 0;
+    min-height: 4.5rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    border-right: 1px solid var(--color-rule);
+    color: var(--color-paper-muted);
     font-family: var(--font-display), sans-serif;
-    font-size: clamp(3.25rem, 13vw, 4.25rem);
-    line-height: 0.82;
-    letter-spacing: -0.02em;
+    font-size: 0.62rem;
+    letter-spacing: 0.09em;
+    line-height: 1;
     text-transform: uppercase;
-    transition: color 160ms ease;
+    transition:
+      color 160ms ease,
+      background-color 160ms ease;
   }
 
-  .mobileNavigationLinks a:hover,
-  .mobileNavigationLinks a:focus-visible {
+  .mobileTabs a:last-child {
+    border-right: 0;
+  }
+
+  .mobileTabs a:hover,
+  .mobileTabs a:focus-visible,
+  .mobileTabs a[aria-current="location"] {
     color: var(--color-gold);
-  }
-
-  @media (max-height: 44rem) {
-    .mobileNavigation {
-      padding-top: 5.9rem;
-    }
-
-    .mobileNavigationLinks {
-      gap: 0.8rem;
-      padding-top: 0.4rem;
-    }
-
-    .mobileNavigation a {
-      font-size: clamp(3rem, 12vw, 3.7rem);
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .mobileNavigation {
-      transition: none;
-    }
+    background: rgb(214 166 62 / 0.08);
   }
 
   .hero {

--- a/src/app/home/HomePage.module.css
+++ b/src/app/home/HomePage.module.css
@@ -986,7 +986,6 @@
     z-index: 60;
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    border-top: 1px solid var(--color-rule);
     padding-bottom: env(safe-area-inset-bottom);
     background: rgb(11 10 9 / 0.96);
     -webkit-backdrop-filter: blur(12px);
@@ -1001,7 +1000,6 @@
     justify-content: center;
     flex-direction: column;
     gap: 0.35rem;
-    border-right: 1px solid var(--color-rule);
     color: var(--color-paper-muted);
     font-family: var(--font-display), sans-serif;
     font-size: 0.62rem;
@@ -1013,15 +1011,10 @@
       background-color 160ms ease;
   }
 
-  .mobileTabs a:last-child {
-    border-right: 0;
-  }
-
   .mobileTabs a:hover,
   .mobileTabs a:focus-visible,
   .mobileTabs a[aria-current="location"] {
     color: var(--color-gold);
-    background: rgb(214 166 62 / 0.08);
   }
 
   .hero {

--- a/src/app/home/NavBar.tsx
+++ b/src/app/home/NavBar.tsx
@@ -92,6 +92,10 @@ export function NavBar({
         </a>
       </nav>
 
+      <a className={styles.mobileBooking} href={bookingHref}>
+        Check availability
+      </a>
+
       <nav className={styles.mobileTabs} aria-label="Explore this page">
         {navigation.map((item) => {
           const Icon = mobileTabIcons[item.href as keyof typeof mobileTabIcons];

--- a/src/app/home/NavBar.tsx
+++ b/src/app/home/NavBar.tsx
@@ -76,25 +76,27 @@ export function NavBar({
   }, [navigation]);
 
   return (
-    <header className={`${styles.nav} ${scrolled ? styles.navScrolled : ""}`}>
-      <a className={styles.brand} href="#top" aria-label={`${name}, home`}>
-        {name}
-      </a>
+    <>
+      <header className={`${styles.nav} ${scrolled ? styles.navScrolled : ""}`}>
+        <a className={styles.brand} href="#top" aria-label={`${name}, home`}>
+          {name}
+        </a>
 
-      <nav className={styles.desktopNavigation} aria-label="Primary navigation">
-        {navigation.map((item) => (
-          <a key={item.href} href={item.href}>
-            {item.label}
+        <nav className={styles.desktopNavigation} aria-label="Primary navigation">
+          {navigation.map((item) => (
+            <a key={item.href} href={item.href}>
+              {item.label}
+            </a>
+          ))}
+          <a className={styles.navBooking} href={bookingHref}>
+            Check availability
           </a>
-        ))}
-        <a className={styles.navBooking} href={bookingHref}>
+        </nav>
+
+        <a className={styles.mobileBooking} href={bookingHref}>
           Check availability
         </a>
-      </nav>
-
-      <a className={styles.mobileBooking} href={bookingHref}>
-        Check availability
-      </a>
+      </header>
 
       <nav className={styles.mobileTabs} aria-label="Explore this page">
         {navigation.map((item) => {
@@ -115,6 +117,6 @@ export function NavBar({
           );
         })}
       </nav>
-    </header>
+    </>
   );
 }

--- a/src/app/home/NavBar.tsx
+++ b/src/app/home/NavBar.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { Menu, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { CalendarDays, Images, Music2, Video } from "lucide-react";
+import { useEffect, useState } from "react";
 import styles from "./HomePage.module.css";
 
 type NavigationItem = {
   label: string;
   href: string;
+};
+
+const mobileTabIcons = {
+  "#music": Music2,
+  "#videos": Video,
+  "#photographs": Images,
+  "#events": CalendarDays,
 };
 
 export function NavBar({
@@ -18,10 +25,8 @@ export function NavBar({
   navigation: NavigationItem[];
   bookingHref: string;
 }) {
-  const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
-  const mobileNavigationRef = useRef<HTMLElement>(null);
+  const [activeMobileTab, setActiveMobileTab] = useState<string | null>(null);
 
   useEffect(() => {
     const update = () => setScrolled(window.scrollY > 24);
@@ -31,60 +36,48 @@ export function NavBar({
   }, []);
 
   useEffect(() => {
-    if (!open) return;
+    const mobileQuery = window.matchMedia("(max-width: 899px)");
+    let frame: number | null = null;
 
-    const previousOverflow = document.body.style.overflow;
-    const menuButton = menuButtonRef.current;
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setOpen(false);
+    const updateActiveTab = () => {
+      frame = null;
+
+      if (!mobileQuery.matches) {
+        setActiveMobileTab(null);
         return;
       }
 
-      if (event.key !== "Tab") return;
+      const activationLine = 96;
+      const visibleSection = [...navigation]
+        .reverse()
+        .find((item) => {
+          const section = document.querySelector(item.href);
+          return section instanceof HTMLElement && section.getBoundingClientRect().top <= activationLine;
+        });
 
-      const focusableItems = mobileNavigationRef.current?.querySelectorAll<HTMLElement>(
-        'a[href]',
-      );
-      if (!focusableItems?.length) return;
-
-      const firstItem = focusableItems[0];
-      const lastItem = focusableItems[focusableItems.length - 1];
-
-      if (event.shiftKey && document.activeElement === firstItem) {
-        event.preventDefault();
-        lastItem.focus();
-      } else if (!event.shiftKey && document.activeElement === lastItem) {
-        event.preventDefault();
-        firstItem.focus();
-      }
+      setActiveMobileTab(visibleSection?.href ?? null);
     };
 
-    document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", closeOnEscape);
-    window.requestAnimationFrame(() => {
-      mobileNavigationRef.current?.querySelector<HTMLElement>('a[href]')?.focus();
-    });
+    const requestUpdate = () => {
+      if (frame === null) frame = window.requestAnimationFrame(updateActiveTab);
+    };
+
+    updateActiveTab();
+    window.addEventListener("scroll", requestUpdate, { passive: true });
+    window.addEventListener("resize", requestUpdate);
+    mobileQuery.addEventListener("change", requestUpdate);
 
     return () => {
-      document.body.style.overflow = previousOverflow;
-      window.removeEventListener("keydown", closeOnEscape);
-      menuButton?.focus({ preventScroll: true });
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      window.removeEventListener("scroll", requestUpdate);
+      window.removeEventListener("resize", requestUpdate);
+      mobileQuery.removeEventListener("change", requestUpdate);
     };
-  }, [open]);
-
-  useEffect(() => {
-    const closeOnDesktop = () => {
-      if (window.matchMedia("(min-width: 900px)").matches) setOpen(false);
-    };
-
-    window.addEventListener("resize", closeOnDesktop);
-    return () => window.removeEventListener("resize", closeOnDesktop);
-  }, []);
+  }, [navigation]);
 
   return (
     <header className={`${styles.nav} ${scrolled ? styles.navScrolled : ""}`}>
-      <a className={styles.brand} href="#top" onClick={() => setOpen(false)}>
+      <a className={styles.brand} href="#top" aria-label={`${name}, home`}>
         {name}
       </a>
 
@@ -99,32 +92,24 @@ export function NavBar({
         </a>
       </nav>
 
-      <button
-        type="button"
-        className={styles.menuButton}
-        ref={menuButtonRef}
-        aria-expanded={open}
-        aria-controls="mobile-navigation"
-        aria-label={open ? "Close navigation" : "Open navigation"}
-        onClick={() => setOpen((current) => !current)}
-      >
-        {open ? <X size={24} /> : <Menu size={24} />}
-      </button>
+      <nav className={styles.mobileTabs} aria-label="Explore this page">
+        {navigation.map((item) => {
+          const Icon = mobileTabIcons[item.href as keyof typeof mobileTabIcons];
 
-      <nav
-        id="mobile-navigation"
-        ref={mobileNavigationRef}
-        className={`${styles.mobileNavigation} ${open ? styles.mobileNavigationOpen : ""}`}
-        aria-label="Mobile navigation"
-        aria-hidden={!open}
-      >
-        <div className={styles.mobileNavigationLinks}>
-          {navigation.map((item) => (
-            <a key={item.href} href={item.href} onClick={() => setOpen(false)}>
-              {item.label}
+          if (!Icon) return null;
+
+          return (
+            <a
+              key={item.href}
+              href={item.href}
+              aria-current={activeMobileTab === item.href ? "location" : undefined}
+              onClick={() => setActiveMobileTab(item.href)}
+            >
+              <Icon size={18} strokeWidth={1.7} aria-hidden="true" />
+              <span>{item.label}</span>
             </a>
-          ))}
-        </div>
+          );
+        })}
       </nav>
     </header>
   );


### PR DESCRIPTION
Closes #39

## Changes

- replace the mobile hamburger menu with a fixed Music, Videos, Photos, and Events tab bar
- stack each tab’s icon above its label for clearer phone-scale scanning
- add a compact persistent **Check availability** CTA beside the mobile wordmark
- keep the wordmark as the return-to-top control, leaving the hero with no selected tab
- update the active tab as its section reaches the fixed header
- preserve desktop navigation and add safe-area/content clearance for the tab bar

## Validation

- `pnpm lint`
- `pnpm build`
- `git diff --check`
- manual browser review at 390×844: header CTA, vertically stacked tabs, hero state, Events anchor placement, active Events state, and bottom-bar clearance
- desktop browser check: primary navigation remains visible and the mobile bar is hidden

## Docs updated

- Not needed; this is a focused navigation refinement.

## Follow-ups

- This draft remains open for the additional, reviewable 2026_07 polish work discussed with the user.
- The existing living-poster implementation and untracked artwork assets remain out of scope.